### PR TITLE
Extend mediate device (mdev) support for device plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
       - [Verify Pod network interfaces](#verify-pod-network-interfaces)
       - [Verify Pod routing table](#verify-pod-routing-table)
     - [Pod device information](#pod-device-information)
+- [New mdev device plugin](#new-mdev-device-plugin)
 - [Issues and Contributing](#issues-and-contributing)
 
 ## SRIOV Network Device Plugin
@@ -300,6 +301,29 @@ The allocated device information are exported in Container's environment variabl
 
 For example, if 2 devices are allocated from `intel.com/sriov` extended resource then the allocated device information will be found in following env variable:
 `PCIDEVICE_INTEL_COM_SRIOV=0000:03:02.1,0000:03:04.3`
+
+## New mdev device plugin
+
+We extended this Kubernetes device plugin for mediate device (mdev) support, which is a recent addition to linux vfio framework that is currently used by, e.g. Intel Graphics Virtualization (GVT-g).
+
+This plugin also creates device plugin endpoints based on the configurations given in file `/etc/pcidp/config.json`. This configuration file is in json format as shown below (with "mdevMode" parameter is true).
+
+```json
+{
+    "resourceList":
+    [
+        {
+            "resourceName": "vgpu",
+            "rootDevices": [ "00:02.0" ],
+            "mdevMode": true,
+            "deviceType": "vfio"
+        }
+    ]
+}
+
+```
+
+It will discover the root devices corresponding mediate devices by UUID. The you can follow the same steps of SRIOV device plugin to create Pod with mdev devices.
 
 ## Issues and Contributing
 

--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -154,6 +154,17 @@ func (rm *resourceManager) validConfigs() bool {
 			}
 		}
 
+		// validate MDEV
+		if conf.MdevMode {
+			// Check that MDEV devices are created for all root devices
+			for _, addr := range pciAddrs {
+				if configured := utils.MdevConfigured(addr); !configured {
+					glog.Errorf("no Mdev configured for root device %s", addr)
+					return false
+				}
+			}
+		}
+
 		// [To-Do]: Validate deviceType
 
 		resourceName[conf.ResourceName] = conf.ResourceName

--- a/deployments/config-vgpu.json
+++ b/deployments/config-vgpu.json
@@ -1,0 +1,11 @@
+{
+    "resourceList":
+    [
+        {
+            "resourceName": "vgpu",
+            "rootDevices": [ "00:02.0" ],
+            "mdevMode": true,
+            "deviceType": "vfio"
+        }
+    ]
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -31,6 +31,7 @@ type ResourceConfig struct {
 	RootDevices  []string `json:"rootDevices"`          // list of PCI address of root devices e.g. "0000:05:00.0",
 	DeviceType   string   `json:"deviceType,omitempty"` // Device driver type of the device
 	SriovMode    bool     `json:"sriovMode,omitempty"`  // Whether devices have SRIOV virtual function capabilities or not
+	MdevMode     bool     `json:"mdevMode,omitempty"`   // Whether devices have Mediate device capabilities or not
 }
 
 // ResourceConfList is list of ResourceConfig


### PR DESCRIPTION
Sriovdp can work as a generic device plugin for all vfio devices.
mediated device (mdev) is a recent addition to linux vfio framework
that is currently used by, e.g. Intel Graphics Virtualization (GVT-g).

This patch adds capability for system administrators to enable mdev
devices for containers.

Signed-off-by: Terrence Xu <terrence.xu@intel.com>