### PR TITLE
Disable GO111MODULE when building openshift/origin image

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -6,6 +6,7 @@ WORKDIR /usr/src/sriov-network-device-plugin
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
+ENV GO111MODULE=off
 RUN make clean && \
     make build
 


### PR DESCRIPTION
This commit also removes glide files