### PR TITLE
Add support for running inside a VM with vfio-noiommu

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,15 @@ containers using this mode.  Use of this mode, specifically
 binding a device without a native IOMMU group to a VFIO bus driver will taint the kernel.  Only no-iommu support for the vfio-pci bus is provided.  However, there are still those users
 that want userspace drivers even under those conditions.
 
+Unfortunately, the SR-IOV CNI is not compatible with the _noiommu_ feature.  To use the _noiommu_ feature, remove the 
+networks annotation from the container spec.  To foster compatiblity between virtual and baremetal deployments creating the associated SrioveNetwork CR is recommended.
+
+````yaml
+  annotations:
+#    k8s.v1.cni.cncf.io/networks: sriov-net1
+  ...
+````
+
 ## Example deployments
 
 We assume that you have working K8s cluster configured with one of the supported meta plugins for multi-network support. Please see [Features](#features) and [Quick Start](#quick-start) sections for more information on required CNI plugins.

--- a/docs/dpdk/README-virt.md
+++ b/docs/dpdk/README-virt.md
@@ -1,0 +1,102 @@
+# Running DPDK applications in a Kubernetes virtual environment
+
+## Pre-requisites
+
+### Hugepages
+DPDK applications require Hugepages memory. Please refer to the [Hugepages section](http://doc.dpdk.org/guides/linux_gsg/sys_reqs.html#use-of-hugepages-in-the-linux-environment) in DPDK getting started guide on hugespages in DPDK.
+
+Make sure that the virtual environment is enabled for creating VMs with hugepage support.  
+
+Kubernetes nodes can only advertise a single size pre-allocated hugepages. Which means even though one can have both 2M and 1G hugepages in a system, Kubernetes will only recognize the default hugepages as schedulable resources. Workload can request for hugepages using resource requests and limits specifying `hugepage-2Mi` or `hugepage-1Gi` resource references.
+
+> One important thing to note here is that when requesting hugepage resources, either memory or CPU resource requests need to be specified.
+
+For more information on hugepage support in Kubernetes please see [here](https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/).
+
+
+### VF drivers
+DPDK applications require devices to be attached with supported dpdk backend driver.
+* For Intel® x700 series NICs `vfio-pci` is required.
+* For Mellanox ConnectX®-4 Lx, ConnectX®-5 Adapters `mlx5_core` or `mlx5_ib` is required.
+
+Native-bifurcating devices/drivers (i.e. Mellanox/mlx5_*) do not need to run with privilege.  Non-bifurcating devices/drivers (i.e. Intel/vfio-pci) the PODs need to run with privilege.  
+
+### Privileges 
+Certain privileges are required for dpdk application to function properly in Kubernetes Pod. The level of privileges depend on the application and the host device driver attached (as mentioned above).  When running in an environment without a fully virtualized IOMMU, the *enable_unsafe_noiommu_mode* of vfio must be used by creating a modprobe.d file.
+
+````
+# cat /etc/modprobe.d/vfio-noiommu.conf
+options vfio enable_unsafe_noiommu_mode=1
+````
+
+With `vfio-pci` an application must run privilege Pod with  **IPC_LOCK** and **CAP_SYS_RAWIO** capability.
+
+# Example deployment
+This directory includes sample deployment yaml files showing how to deploy a dpdk application in Kubernetes with in privileged Pod with SR-IOV VF attached to vfio-pci driver in the case of non-bifurcating nic devices/drivers or the VF attached to the default driver in the case of native-bifurcating devices/drivers (non-priveleged).  See [this](https://doc.dpdk.org/guides/howto/flow_bifurcation.html) for more information.
+
+## Deploy Virtual machines with attached VFs
+
+1. Depending on the virtualization environment, create a network that supports SR-IOV.  Configure the VF as per your requirements:
+- Trusted On/Off
+- Spoof-Checking On/Off
+
+In a virtual environment, some VF characteristics are set by the underlying virtualization platform and are used 'as is' inside the VM.  A virtual deployment does not have access the VFs associated PF.
+
+2. Attach the VFs or associated ports to the VM
+
+## Check that environment supports VFIO and hugepages memory
+
+1.  After deployment of the VM, confirm that your hugepagesz parameter is present. 
+````
+sh-4.4# cat /proc/cmdline 
+BOOT_IMAGE=(hd0,gpt1)/ostree/rhcos-92d66d9df4cafad87abd888fd1b22fd1d890e86bc2ad8b9009bb9faa4f403a95/vmlinuz-4.18.0-193.24.1.el8_2.dt1.x86_64 rhcos.root=crypt_rootfs random.trust_cpu=on console=tty0 console=ttyS0,115200n8 rd.luks.options=discard ostree=/ostree/boot.1/rhcos/92d66d9df4cafad87abd888fd1b22fd1d890e86bc2ad8b9009bb9faa4f403a95/0 ignition.platform.id=openstack nohz=on nosoftlockup skew_tick=1 intel_pstate=disable intel_iommu=on iommu=pt rcu_nocbs=2-3 tuned.non_isolcpus=00000003 default_hugepagesz=1G nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
+````
+2. On the desired worker node, 
+
+````
+cat /proc/meminfo | grep -i hugepage
+AnonHugePages:    245760 kB
+ShmemHugePages:        0 kB
+HugePages_Total:       8
+HugePages_Free:        8
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:    1048576 kB
+````
+You should see your requested hugepage size and a non-zero HugePages_Total.
+
+3. Confirm that Hugepages memory are allocated and mounted
+```
+# cat /proc/meminfo | grep -i hugepage
+HugePages_Total:      16
+HugePages_Free:       16
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:    1048576 kB
+
+# mount | grep hugetlbfs
+hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime)
+
+```
+
+5. Load vfio-pci module
+
+````
+# echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
+````
+
+```
+modprobe vfio-pci
+```
+
+7. For non-bifurcating devices/drivers, bind the appropriate interfaces (VF) to the vfio-pci driver.  You can use or `driverctl` or [`dpdk-devbind.py`](https://github.com/DPDK/dpdk/blob/master/usertools/dpdk-devbind.py) to bind/unbind drivers using devices PCI addresses. Please see [here](https://dpdk-guide.gitlab.io/dpdk-guide/setup/binding.html) more information on NIC driver bindings.
+
+Native-bifurcating devices/drivers can stay with the default binding.
+
+# Performance
+It is worth mentioning that to achieve maximum performance from a dpdk application the followings are required:
+
+1. Application process needs to be pinned to some dedicated isolated CPUs. Detailing how to achieve this is out of scope of this document. You can refer to [CPU Manager for Kubernetes](https://github.com/intel/CPU-Manager-for-Kubernetes) that provides such functionality in Kubernetes.  In the virtualized case, cpu pinning and isolation must be considered at the phyiscal layer as well as the virtual layer.
+
+2. All application resources(CPUs, devices and memory) are from same NUMA locality.  In the virtualized case, NUMA locality is controlled by the underlying virtualized platform for the VM.
+

--- a/docs/dpdk/README-virt.md
+++ b/docs/dpdk/README-virt.md
@@ -32,7 +32,7 @@ options vfio enable_unsafe_noiommu_mode=1
 With `vfio-pci` an application must run privilege Pod with  **IPC_LOCK** and **CAP_SYS_RAWIO** capability.
 
 # Example deployment
-This directory includes sample deployment yaml files showing how to deploy a dpdk application in Kubernetes with in privileged Pod with SR-IOV VF attached to vfio-pci driver in the case of non-bifurcating nic devices/drivers or the VF attached to the default driver in the case of native-bifurcating devices/drivers (non-priveleged).  See [this](https://doc.dpdk.org/guides/howto/flow_bifurcation.html) for more information.
+This directory includes a sample deployment yaml files showing how to deploy a dpdk application in Kubernetes with a privileged Pod (_pod_testpmd_virt.yaml_). 
 
 ## Deploy Virtual machines with attached VFs
 
@@ -40,7 +40,7 @@ This directory includes sample deployment yaml files showing how to deploy a dpd
 - Trusted On/Off
 - Spoof-Checking On/Off
 
-In a virtual environment, some VF characteristics are set by the underlying virtualization platform and are used 'as is' inside the VM.  A virtual deployment does not have access the VFs associated PF.
+In a virtual environment, some VF characteristics are set by the underlying virtualization platform and are used 'as is' inside the VM.  A virtual deployment does not have access to the VFs associated PF.
 
 2. Attach the VFs or associated ports to the VM
 
@@ -99,4 +99,16 @@ It is worth mentioning that to achieve maximum performance from a dpdk applicati
 1. Application process needs to be pinned to some dedicated isolated CPUs. Detailing how to achieve this is out of scope of this document. You can refer to [CPU Manager for Kubernetes](https://github.com/intel/CPU-Manager-for-Kubernetes) that provides such functionality in Kubernetes.  In the virtualized case, cpu pinning and isolation must be considered at the phyiscal layer as well as the virtual layer.
 
 2. All application resources(CPUs, devices and memory) are from same NUMA locality.  In the virtualized case, NUMA locality is controlled by the underlying virtualized platform for the VM.
+
+# Pod Usage
+
+Unfortunately, the SR-IOV CNI is not compatible with the noiommu feature.  To use the noiommu feature, remove the 
+networks annotation from the container spec.
+
+````yaml
+  annotations:
+#   k8s.v1.cni.cncf.io/networks: sriov-net1
+````
+A full example of a noiommu deployment is shown in
+_pod_testpmd.yaml_.
 

--- a/docs/dpdk/README-virt.md
+++ b/docs/dpdk/README-virt.md
@@ -26,7 +26,11 @@ The presence of noiommu-* devices will automatically be detected by the sriov-de
 ...
 ````
 It should be noted that with no IOMMU, there is no way to ensure safe use of DMA.  When *enable_unsafe_noiommu_mode* is used, CAP_SYS_RAWIO privileges are necessary to work with groups and
-containers using this mode.  Use of this mode, specifically
+containers using this mode.  
+
+>Note: The most common use case for direct VF is with the **DPDK** framework which will require the use of privileged containers.
+
+Use of this mode, specifically
 binding a device without a native IOMMU group to a VFIO bus driver will taint the kernel.  Only no-iommu support for the vfio-pci bus is provided.  However, there are still those users
 that want userspace drivers even under those conditions.
 
@@ -130,8 +134,8 @@ It is worth mentioning that to achieve maximum performance from a dpdk applicati
 
 # Usage
 
-_When consuming a VFIO device in a virtual environment, a secondary network is not required as network configuration for the underlying VF should be performed at the hypervisor level._
+>When consuming a VFIO device in a virtual environment, a secondary network is not required as network configuration for the underlying VF should be performed at the hypervisor level.
 
-An example of a noiommu deployment is shown in _pod_testpmd_virt.yaml_.  The configMap for the example is shown in _configMap-virt.yaml_.
+An example of a noiommu deployment is shown in [pod_testpmd_virt.yaml](pod_testpmd_virt.yaml).  The configMap for the example is shown in [configMap-virt.yaml](configMap-virt.yaml).
 
 

--- a/docs/dpdk/configMap-virt.yaml
+++ b/docs/dpdk/configMap-virt.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+      "resourceList": [
+        {
+          "resourceName": "intelnics_radio_downlink",
+          "selectors": {
+            "drivers": [
+              "vfio-pci"
+            ],
+            "pciAddresses": [
+              "0000:00:09.0",
+              "0000:00:0a.0"
+            ],
+          },
+        },
+        {
+          "resourceName": "intelnics_radio_uplink",
+          "selectors": {
+            "drivers": [
+              "vfio-pci"
+            ],
+            "pciAddresses": [
+              "0000:00:07.0",
+              "0000:00:08.0"
+            ],
+          },
+        }
+      ]
+    }

--- a/docs/dpdk/pod_testpmd_virt.yaml
+++ b/docs/dpdk/pod_testpmd_virt.yaml
@@ -2,9 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: testpmd
-#  annotations:
-#    k8s.v1.cni.cncf.io/networks: sriov-dpdk-net2000
-
 spec:
   containers:
   - name: testpmd
@@ -13,12 +10,14 @@ spec:
         privileged: true
     resources:
       requests:
-        intel.com/intel_x710vfio: "2"
+        openshift.io/intelnics_radio_downlink: "1"
+        openshift.io/intelnics_radio_uplink: "1"
         memory: 1000Mi
         hugepages-1Gi: 2Gi
         cpu: '1'
       limits:
-        intel.com/intel_x710vfio: "2"
+        openshift.io/intelnics_radio_downlink: "1"
+        openshift.io/intelnics_radio_uplink: "1"
         hugepages-1Gi: 2Gi
         cpu: '1'
         memory: 2000Mi

--- a/docs/dpdk/pod_testpmd_virt.yaml
+++ b/docs/dpdk/pod_testpmd_virt.yaml
@@ -7,6 +7,7 @@ spec:
   - name: testpmd
     image: <DPDK testpmd image>
     securityContext:
+        # This application is DPDK-based
         privileged: true
     resources:
       requests:

--- a/docs/dpdk/pod_testpmd_virt.yaml
+++ b/docs/dpdk/pod_testpmd_virt.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testpmd
+#  annotations:
+#    k8s.v1.cni.cncf.io/networks: sriov-dpdk-net2000
+
+spec:
+  containers:
+  - name: testpmd
+    image: <DPDK testpmd image>
+    securityContext:
+        privileged: true
+    resources:
+      requests:
+        intel.com/intel_x710vfio: "2"
+        memory: 1000Mi
+        hugepages-1Gi: 2Gi
+        cpu: '1'
+      limits:
+        intel.com/intel_x710vfio: "2"
+        hugepages-1Gi: 2Gi
+        cpu: '1'
+        memory: 2000Mi
+    volumeMounts:
+      - mountPath: /dev/hugepages
+        name: hugepage
+        readOnly: False
+  volumes:
+  - name: hugepage
+    emptyDir:
+      medium: HugePages

--- a/pkg/resources/vfioResource.go
+++ b/pkg/resources/vfioResource.go
@@ -50,13 +50,13 @@ func (rp *vfioResource) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
 		Permissions:   "mrw",
 	})
 
-	vfioDev, err := utils.GetVFIODeviceFile(pciAddr)
+	vfioDevHost, vfioDevContainer, err := utils.GetVFIODeviceFile(pciAddr)
 	if err != nil {
-		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s", pciAddr)
+		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s, %s", pciAddr, err.Error())
 	} else {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
-			HostPath:      vfioDev,
-			ContainerPath: vfioDev,
+			HostPath:      vfioDevHost,
+			ContainerPath: vfioDevContainer,
 			Permissions:   "mrw",
 		})
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -296,8 +296,9 @@ var _ = Describe("In the utils package", func() {
 	DescribeTable("getting VFIO device file",
 		func(fs *FakeFilesystem, device, expected string, shouldFail bool) {
 			defer fs.Use()()
-			actual, err := GetVFIODeviceFile(device)
-			Expect(actual).To(Equal(expected))
+			//TODO: adapt test to running in a virtual environment
+			actualHost, _, err := GetVFIODeviceFile(device)
+			Expect(actualHost).To(Equal(expected))
 			assertShouldFail(err, shouldFail)
 		},
 		Entry("could not get directory information for device",


### PR DESCRIPTION
This PR is required for https://github.com/openshift/sriov-network-operator/pull/369.

This PR enables the mapping of a no-iommu vfio device into a container.  

Associated system configuration enables no-iommu for the vfio-pci driver.

This PR is required to allow Kubernetes to run in a virtual environment that does not provide a virtualized iommu.  The initial target environment is OpenStack.  OpenStack Nova does not currently provide a virtualized iommu. Support for vfio-noiommu was added to linux a few years ago with the caveats outlined below...

`There is really no way to safely give a user full access to a DMA
capable device without an IOMMU to protect the host system.  There is
also no way to provide DMA translation, for use cases such as device
assignment to virtual machines.  However, there are still those users
that want userspace drivers even under those conditions.  The UIO
driver exists for this use case, but does not provide the degree of
device access and programming that VFIO has.  In an effort to avoid
code duplication, this introduces a No-IOMMU mode for VFIO.

This mode requires building VFIO with CONFIG_VFIO_NOIOMMU and enabling
the "enable_unsafe_noiommu_mode" option on the vfio driver.  This
should make it very clear that this mode is not safe.  Additionally,
CAP_SYS_RAWIO privileges are necessary to work with groups and
containers using this mode.  Groups making use of this support are
named /dev/vfio/noiommu-$GROUP and can only make use of the special
VFIO_NOIOMMU_IOMMU for the container.  Use of this mode, specifically
binding a device without a native IOMMU group to a VFIO bus driver
will taint the kernel and should therefore not be considered
supported.  This patch includes no-iommu support for the vfio-pci bus
driver only.`

In the future, the current QEMU machine type in use for OpenStack is i440fx.  The
machine type should be switched to Q35 in the future.  The Q35 machine provides
a virtualized iommu implementation and will obsolete this patch.  

In summary, the use of noiommu introduces security concerns, but the performance
boost provided by vfio-pci can be justified in many cases.