### PR TITLE
Use DeviceInfoProviders for all DeviceSpec generation

### DIFF
--- a/pkg/accelerator/accelDevice.go
+++ b/pkg/accelerator/accelDevice.go
@@ -29,7 +29,7 @@ type accelDevice struct {
 // NewAccelDevice returns an instance of AccelDevice interface
 func NewAccelDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory) (types.AccelDevice, error) {
 
-	pciDev, err := resources.NewPciDevice(dev, rFactory)
+	pciDev, err := resources.NewPciDevice(dev, rFactory, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -60,8 +60,8 @@ func (rf *resourceFactory) GetResourceServer(rp types.ResourcePool) (types.Resou
 	return nil, fmt.Errorf("factory: unable to get resource pool object")
 }
 
-// GetInfoProvider returns an instance of DeviceInfoProvider using name as string
-func (rf *resourceFactory) GetInfoProvider(name string) types.DeviceInfoProvider {
+// GetDefaultInfoProvider returns an instance of DeviceInfoProvider using name as string
+func (rf *resourceFactory) GetDefaultInfoProvider(name string) types.DeviceInfoProvider {
 	switch name {
 	case "vfio-pci":
 		return resources.NewVfioResource()

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -61,14 +61,14 @@ func (rf *resourceFactory) GetResourceServer(rp types.ResourcePool) (types.Resou
 }
 
 // GetDefaultInfoProvider returns an instance of DeviceInfoProvider using name as string
-func (rf *resourceFactory) GetDefaultInfoProvider(name string) types.DeviceInfoProvider {
+func (rf *resourceFactory) GetDefaultInfoProvider(pciAddr string, name string) types.DeviceInfoProvider {
 	switch name {
 	case "vfio-pci":
-		return resources.NewVfioInfoProvider()
+		return resources.NewVfioInfoProvider(pciAddr)
 	case "uio", "igb_uio":
-		return resources.NewUioInfoProvider()
+		return resources.NewUioInfoProvider(pciAddr)
 	default:
-		return resources.NewGenericInfoProvider()
+		return resources.NewGenericInfoProvider(pciAddr)
 	}
 }
 

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -64,11 +64,11 @@ func (rf *resourceFactory) GetResourceServer(rp types.ResourcePool) (types.Resou
 func (rf *resourceFactory) GetDefaultInfoProvider(name string) types.DeviceInfoProvider {
 	switch name {
 	case "vfio-pci":
-		return resources.NewVfioResource()
+		return resources.NewVfioInfoProvider()
 	case "uio", "igb_uio":
-		return resources.NewUioResource()
+		return resources.NewUioInfoProvider()
 	default:
-		return resources.NewGenericResource()
+		return resources.NewGenericInfoProvider()
 	}
 }
 

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Factory", func() {
 	DescribeTable("getting info provider",
 		func(name string, expected reflect.Type) {
 			f := factory.NewResourceFactory("fake", "fake", true)
-			p := f.GetInfoProvider(name)
+			p := f.GetDefaultInfoProvider(name)
 			Expect(reflect.TypeOf(p)).To(Equal(expected))
 		},
 		Entry("vfio-pci", "vfio-pci", reflect.TypeOf(resources.NewVfioResource())),

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -54,10 +54,10 @@ var _ = Describe("Factory", func() {
 			p := f.GetDefaultInfoProvider(name)
 			Expect(reflect.TypeOf(p)).To(Equal(expected))
 		},
-		Entry("vfio-pci", "vfio-pci", reflect.TypeOf(resources.NewVfioResource())),
-		Entry("uio", "uio", reflect.TypeOf(resources.NewUioResource())),
-		Entry("igb_uio", "igb_uio", reflect.TypeOf(resources.NewUioResource())),
-		Entry("any other value", "netdevice", reflect.TypeOf(resources.NewGenericResource())),
+		Entry("vfio-pci", "vfio-pci", reflect.TypeOf(resources.NewVfioInfoProvider())),
+		Entry("uio", "uio", reflect.TypeOf(resources.NewUioInfoProvider())),
+		Entry("igb_uio", "igb_uio", reflect.TypeOf(resources.NewUioInfoProvider())),
+		Entry("any other value", "netdevice", reflect.TypeOf(resources.NewGenericInfoProvider())),
 	)
 	DescribeTable("getting selector",
 		func(selector string, shouldSucceed bool, expected reflect.Type) {

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -51,13 +51,13 @@ var _ = Describe("Factory", func() {
 	DescribeTable("getting info provider",
 		func(name string, expected reflect.Type) {
 			f := factory.NewResourceFactory("fake", "fake", true)
-			p := f.GetDefaultInfoProvider(name)
+			p := f.GetDefaultInfoProvider("fakePCIAddr", name)
 			Expect(reflect.TypeOf(p)).To(Equal(expected))
 		},
-		Entry("vfio-pci", "vfio-pci", reflect.TypeOf(resources.NewVfioInfoProvider())),
-		Entry("uio", "uio", reflect.TypeOf(resources.NewUioInfoProvider())),
-		Entry("igb_uio", "igb_uio", reflect.TypeOf(resources.NewUioInfoProvider())),
-		Entry("any other value", "netdevice", reflect.TypeOf(resources.NewGenericInfoProvider())),
+		Entry("vfio-pci", "vfio-pci", reflect.TypeOf(resources.NewVfioInfoProvider("fakePCIAddr"))),
+		Entry("uio", "uio", reflect.TypeOf(resources.NewUioInfoProvider("fakePCIAddr"))),
+		Entry("igb_uio", "igb_uio", reflect.TypeOf(resources.NewUioInfoProvider("fakePCIAddr"))),
+		Entry("any other value", "netdevice", reflect.TypeOf(resources.NewGenericInfoProvider("fakePCIAddr"))),
 	)
 	DescribeTable("getting selector",
 		func(selector string, shouldSucceed bool, expected reflect.Type) {

--- a/pkg/netdevice/netInfoProviders.go
+++ b/pkg/netdevice/netInfoProviders.go
@@ -56,3 +56,33 @@ func (rip *rdmaInfoProvider) GetEnvVal(pciAddr string) string {
 func (rip *rdmaInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
 	return nil
 }
+
+/*
+   VhostNetInfoProvider wraps any DeviceInfoProvider and adds a vhost-net device
+*/
+type vhostNetInfoProvider struct {
+}
+
+// NewVhostNetInfoProvider returns a new Vhost Information Provider
+func NewVhostNetInfoProvider() types.DeviceInfoProvider {
+	return &vhostNetInfoProvider{}
+}
+
+// *****************************************************************
+/* DeviceInfoProvider Interface */
+
+func (rip *vhostNetInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+	if !VhostNetDeviceExist() {
+		glog.Errorf("GetDeviceSpecs(): /dev/vhost-net doesn't exist")
+		return nil
+	}
+	return GetVhostNetDeviceSpec()
+}
+
+func (rip *vhostNetInfoProvider) GetEnvVal(pciAddr string) string {
+	return pciAddr
+}
+
+func (rip *vhostNetInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+	return nil
+}

--- a/pkg/netdevice/netInfoProviders.go
+++ b/pkg/netdevice/netInfoProviders.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netdevice
+
+import (
+	"github.com/golang/glog"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+)
+
+/*
+   rdmaInfoProvider provides the RDMA information
+*/
+type rdmaInfoProvider struct {
+	rdmaSpec types.RdmaSpec
+}
+
+// NewRdmaInfoProvider returns a new Rdma Information Provider
+func NewRdmaInfoProvider(rdmaSpec types.RdmaSpec) types.DeviceInfoProvider {
+	return &rdmaInfoProvider{
+		rdmaSpec: rdmaSpec,
+	}
+}
+
+// *****************************************************************
+/* DeviceInfoProvider Interface */
+
+func (rip *rdmaInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+	if !rip.rdmaSpec.IsRdma() {
+		glog.Errorf("GetDeviceSpecs(): rdma is required in the configuration but the device %s is not rdma device", pciAddr)
+		return nil
+	}
+	return rip.rdmaSpec.GetRdmaDeviceSpec()
+}
+
+func (rip *rdmaInfoProvider) GetEnvVal(pciAddr string) string {
+	return pciAddr
+}
+
+func (rip *rdmaInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+	return nil
+}

--- a/pkg/netdevice/netInfoProviders.go
+++ b/pkg/netdevice/netInfoProviders.go
@@ -41,19 +41,19 @@ func NewRdmaInfoProvider(rdmaSpec types.RdmaSpec) types.DeviceInfoProvider {
 // *****************************************************************
 /* DeviceInfoProvider Interface */
 
-func (rip *rdmaInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rip *rdmaInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	if !rip.rdmaSpec.IsRdma() {
-		glog.Errorf("GetDeviceSpecs(): rdma is required in the configuration but the device %s is not rdma device", pciAddr)
+		glog.Errorf("GetDeviceSpecs(): rdma is required in the configuration but the device is not rdma device")
 		return nil
 	}
 	return rip.rdmaSpec.GetRdmaDeviceSpec()
 }
 
-func (rip *rdmaInfoProvider) GetEnvVal(pciAddr string) string {
-	return pciAddr
+func (rip *rdmaInfoProvider) GetEnvVal() string {
+	return ""
 }
 
-func (rip *rdmaInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rip *rdmaInfoProvider) GetMounts() []*pluginapi.Mount {
 	return nil
 }
 
@@ -71,7 +71,7 @@ func NewVhostNetInfoProvider() types.DeviceInfoProvider {
 // *****************************************************************
 /* DeviceInfoProvider Interface */
 
-func (rip *vhostNetInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rip *vhostNetInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	if !VhostNetDeviceExist() {
 		glog.Errorf("GetDeviceSpecs(): /dev/vhost-net doesn't exist")
 		return nil
@@ -79,10 +79,10 @@ func (rip *vhostNetInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.Dev
 	return GetVhostNetDeviceSpec()
 }
 
-func (rip *vhostNetInfoProvider) GetEnvVal(pciAddr string) string {
-	return pciAddr
+func (rip *vhostNetInfoProvider) GetEnvVal() string {
+	return ""
 }
 
-func (rip *vhostNetInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rip *vhostNetInfoProvider) GetMounts() []*pluginapi.Mount {
 	return nil
 }

--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -57,14 +57,6 @@ func (rp *netResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Devic
 		if dev, ok := devicePool[id]; ok {
 			netDev := dev.(types.PciNetDevice) // convert generic PciDevice to PciNetDevice
 			newSpecs := netDev.GetDeviceSpecs()
-			if rp.selectors.NeedVhostNet {
-				if VhostNetDeviceExist() {
-					vhostNetDeviceSpec := GetVhostNetDeviceSpec()
-					newSpecs = append(newSpecs, vhostNetDeviceSpec...)
-				} else {
-					glog.Errorf("GetDeviceSpecs(): vhost-net is required in the configuration but /dev/vhost-net doesn't exist")
-				}
-			}
 			for _, ds := range newSpecs {
 				if !rp.DeviceSpecExist(devSpecs, ds) {
 					devSpecs = append(devSpecs, ds)

--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -57,15 +57,6 @@ func (rp *netResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Devic
 		if dev, ok := devicePool[id]; ok {
 			netDev := dev.(types.PciNetDevice) // convert generic PciDevice to PciNetDevice
 			newSpecs := netDev.GetDeviceSpecs()
-			rdmaSpec := netDev.GetRdmaSpec()
-			if rp.selectors.IsRdma {
-				if rdmaSpec.IsRdma() {
-					rdmaDeviceSpec := rdmaSpec.GetRdmaDeviceSpec()
-					newSpecs = append(newSpecs, rdmaDeviceSpec...)
-				} else {
-					glog.Errorf("GetDeviceSpecs(): rdma is required in the configuration but the device %v is not rdma device", id)
-				}
-			}
 			if rp.selectors.NeedVhostNet {
 				if VhostNetDeviceExist() {
 					vhostNetDeviceSpec := GetVhostNetDeviceSpec()

--- a/pkg/netdevice/netResourcePool_test.go
+++ b/pkg/netdevice/netResourcePool_test.go
@@ -48,7 +48,7 @@ var _ = Describe("NetResourcePool", func() {
 		})
 	})
 	Describe("getting DeviceSpecs", func() {
-		Context("for non-RDMA devices", func() {
+		Context("for multiple devices", func() {
 			rf := factory.NewResourceFactory("fake", "fake", true)
 			nadutils := rf.GetNadUtils()
 			rc := &types.ResourceConfig{
@@ -60,29 +60,25 @@ var _ = Describe("NetResourcePool", func() {
 			}
 			devs := map[string]*v1beta1.Device{}
 
-			rdmaNo := &mocks.RdmaSpec{}
-			rdmaNo.On("IsRdma").Return(false)
-
 			// fake1 will have 2 device specs
 			fake1 := &mocks.PciNetDevice{}
 			fake1ds := []*pluginapi.DeviceSpec{
 				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake1a"},
 				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake1b"},
 			}
-			fake1.On("GetDeviceSpecs").Return(fake1ds).On("GetRdmaSpec").Return(rdmaNo)
+			fake1.On("GetDeviceSpecs").Return(fake1ds)
 
 			// fake2 will have 1 device spec
 			fake2 := &mocks.PciNetDevice{}
 			fake2ds := []*pluginapi.DeviceSpec{
 				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake2"},
 			}
-			fake2.On("GetDeviceSpecs").Return(fake2ds).
-				On("GetRdmaSpec").Return(rdmaNo)
+			fake2.On("GetDeviceSpecs").Return(fake2ds)
 
 			// fake3 will have 0 device specs
 			fake3 := &mocks.PciNetDevice{}
 			fake3ds := []*pluginapi.DeviceSpec{}
-			fake2.On("GetDeviceSpecs").Return(fake3ds).On("GetRdmaSpec").Return(rdmaNo)
+			fake3.On("GetDeviceSpecs").Return(fake3ds)
 
 			pcis := map[string]types.PciDevice{"fake1": fake1, "fake2": fake2, "fake3": fake3}
 
@@ -98,52 +94,6 @@ var _ = Describe("NetResourcePool", func() {
 				Expect(actual).To(ContainElement(fake1ds[0]))
 				Expect(actual).To(ContainElement(fake1ds[1]))
 				Expect(actual).To(ContainElement(fake2ds[0]))
-			})
-		})
-		Context("for RDMA devices", func() {
-			rf := factory.NewResourceFactory("fake", "fake", true)
-			nadutils := rf.GetNadUtils()
-			rc := &types.ResourceConfig{
-				ResourceName:   "fake",
-				ResourcePrefix: "fake",
-				SelectorObj: &types.NetDeviceSelectors{
-					IsRdma: true,
-				},
-			}
-			devs := map[string]*v1beta1.Device{}
-			rdma1 := &mocks.RdmaSpec{}
-			rdma2 := &mocks.RdmaSpec{}
-
-			// fake1 will have 2 RDMA device specs and 0 regular device specs
-			fake1 := &mocks.PciNetDevice{}
-			fake1ds := []*pluginapi.DeviceSpec{
-				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake1a"},
-				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake1b"},
-			}
-			rdma1.On("IsRdma").Return(true).On("GetRdmaDeviceSpec").Return(fake1ds)
-			fake1.On("GetRdmaSpec").Return(rdma1).
-				On("GetDeviceSpecs").Return(make([]*pluginapi.DeviceSpec, 0))
-
-			// fake2 will have 0 rdma device specs to trigger error msg
-			fake2 := &mocks.PciNetDevice{}
-			fake2ds := []*pluginapi.DeviceSpec{}
-			rdma2.On("IsRdma").Return(false).On("GetRdmaDeviceSpec").Return(fake2ds)
-			fake2.On("GetDeviceSpecs").Return(make([]*pluginapi.DeviceSpec, 0)).
-				On("GetRdmaSpec").Return(rdma2)
-
-			pcis := map[string]types.PciDevice{"fake1": fake1, "fake2": fake2}
-
-			rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
-
-			devIDs := []string{"fake1", "fake2"}
-
-			actual := rp.GetDeviceSpecs(devIDs)
-
-			It("should return valid slice of device specs", func() {
-				Expect(actual).ToNot(BeNil())
-				Expect(actual).To(HaveLen(2)) // fake1 => 2 rdma devices
-				Expect(actual).To(ContainElement(fake1ds[0]))
-				Expect(actual).To(ContainElement(fake1ds[1]))
 			})
 		})
 	})

--- a/pkg/netdevice/pciNetDevice.go
+++ b/pkg/netdevice/pciNetDevice.go
@@ -37,7 +37,7 @@ type pciNetDevice struct {
 func NewPciNetDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *types.ResourceConfig) (types.PciNetDevice, error) {
 
 	var ifName string
-	pciDev, err := resources.NewPciDevice(dev, rFactory)
+	pciDev, err := resources.NewPciDevice(dev, rFactory, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netdevice/pciNetDevice.go
+++ b/pkg/netdevice/pciNetDevice.go
@@ -35,9 +35,29 @@ type pciNetDevice struct {
 
 // NewPciNetDevice returns an instance of PciNetDevice interface
 func NewPciNetDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *types.ResourceConfig) (types.PciNetDevice, error) {
-
 	var ifName string
-	pciDev, err := resources.NewPciDevice(dev, rFactory, nil)
+	infoProviders := make([]types.DeviceInfoProvider, 0)
+
+	driverName, err := utils.GetDriverName(dev.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(driverName))
+	rdmaSpec := rFactory.GetRdmaSpec(dev.Address)
+	nf, ok := rc.SelectorObj.(*types.NetDeviceSelectors)
+	if ok {
+		// Add InfoProviders based on Selector data
+		if nf.IsRdma {
+			if rdmaSpec.IsRdma() {
+				infoProviders = append(infoProviders, NewRdmaInfoProvider(rdmaSpec))
+			} else {
+				glog.Warningf("RDMA resources for %s not found. Are RDMA modules loaded?", dev.Address)
+			}
+		}
+	}
+
+	pciDev, err := resources.NewPciDevice(dev, rFactory, infoProviders)
 	if err != nil {
 		return nil, err
 	}
@@ -52,14 +72,6 @@ func NewPciNetDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *typ
 	pfName, err := utils.GetPfName(pciAddr)
 	if err != nil {
 		glog.Warningf("unable to get PF name %q", err.Error())
-	}
-
-	rdmaSpec := rFactory.GetRdmaSpec(dev.Address)
-	nf, ok := rc.SelectorObj.(*types.NetDeviceSelectors)
-	if ok {
-		if nf.IsRdma && !rdmaSpec.IsRdma() {
-			glog.Warningf("RDMA resources for %s not found. Are RDMA modules loaded?", pciAddr)
-		}
 	}
 
 	linkType := ""

--- a/pkg/netdevice/pciNetDevice.go
+++ b/pkg/netdevice/pciNetDevice.go
@@ -55,6 +55,13 @@ func NewPciNetDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *typ
 				glog.Warningf("RDMA resources for %s not found. Are RDMA modules loaded?", dev.Address)
 			}
 		}
+		if nf.NeedVhostNet {
+			if VhostNetDeviceExist() {
+				infoProviders = append(infoProviders, NewVhostNetInfoProvider())
+			} else {
+				glog.Errorf("GetDeviceSpecs(): vhost-net is required in the configuration but /dev/vhost-net doesn't exist")
+			}
+		}
 	}
 
 	pciDev, err := resources.NewPciDevice(dev, rFactory, infoProviders)

--- a/pkg/netdevice/pciNetDevice.go
+++ b/pkg/netdevice/pciNetDevice.go
@@ -43,7 +43,7 @@ func NewPciNetDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *typ
 		return nil, err
 	}
 
-	infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(driverName))
+	infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(dev.Address, driverName))
 	rdmaSpec := rFactory.GetRdmaSpec(dev.Address)
 	nf, ok := rc.SelectorObj.(*types.NetDeviceSelectors)
 	if ok {

--- a/pkg/netdevice/pciNetDevice_test.go
+++ b/pkg/netdevice/pciNetDevice_test.go
@@ -18,10 +18,12 @@ import (
 	"testing"
 
 	"github.com/jaypipes/ghw"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/factory"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/netdevice"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types/mocks"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -118,6 +120,88 @@ var _ = Describe("PciNetDevice", func() {
 
 				Expect(dev.GetAPIDevice().Topology).To(BeNil())
 				Expect(dev.GetNumaInfo()).To(Equal(""))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		Context("with two devices but only one of them being RDMA", func() {
+			rc := &types.ResourceConfig{
+				ResourceName:   "fake",
+				ResourcePrefix: "fake",
+				SelectorObj: &types.NetDeviceSelectors{
+					IsRdma: true,
+				},
+			}
+			fs := &utils.FakeFilesystem{
+				Dirs: []string{
+					"sys/bus/pci/devices/0000:00:00.1",
+					"sys/bus/pci/devices/0000:00:00.2/net/eth1",
+					"sys/kernel/iommu_groups/0",
+					"sys/kernel/iommu_groups/1",
+					"sys/bus/pci/drivers/mlx5_core",
+				},
+				Symlinks: map[string]string{
+					"sys/bus/pci/devices/0000:00:00.1/iommu_group": "../../../../kernel/iommu_groups/0",
+					"sys/bus/pci/devices/0000:00:00.2/iommu_group": "../../../../kernel/iommu_groups/1",
+					"sys/bus/pci/devices/0000:00:00.1/driver":      "../../../../bus/pci/drivers/mlx5_core",
+					"sys/bus/pci/devices/0000:00:00.2/driver":      "../../../../bus/pci/drivers/mlx5_core",
+				},
+				Files: map[string][]byte{
+					"sys/bus/pci/devices/0000:00:00.1/numa_node": []byte("0"),
+					"sys/bus/pci/devices/0000:00:00.2/numa_node": []byte("0"),
+				},
+			}
+			defer fs.Use()()
+			defer utils.UseFakeLinks()()
+
+			rdma1 := &mocks.RdmaSpec{}
+			// fake1 will have 2 RDMA device specs
+			fake1ds := []*pluginapi.DeviceSpec{
+				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake1a"},
+				&pluginapi.DeviceSpec{ContainerPath: "/fake/path", HostPath: "/dev/fake1b"},
+			}
+			rdma1.On("IsRdma").Return(true).On("GetRdmaDeviceSpec").Return(fake1ds)
+
+			// fake2 will have 0 rdma device specs to trigger error msg
+			rdma2 := &mocks.RdmaSpec{}
+			rdma2.On("IsRdma").Return(false)
+
+			f := &mocks.ResourceFactory{}
+			f.On("GetDefaultInfoProvider", "mlx5_core").Return(func(s string) types.DeviceInfoProvider {
+				f := factory.NewResourceFactory("fake", "fake", true)
+				return f.GetDefaultInfoProvider("mlx5_core")
+			}).
+				On("GetRdmaSpec", "0000:00:00.1").Return(rdma1).
+				On("GetRdmaSpec", "0000:00:00.2").Return(rdma2)
+
+			in1 := &ghw.PCIDevice{Address: "0000:00:00.1"}
+			in2 := &ghw.PCIDevice{Address: "0000:00:00.2"}
+
+			It("should populate Rdma device specs if isRdma", func() {
+				defer fs.Use()()
+				defer utils.UseFakeLinks()()
+				dev, err := netdevice.NewPciNetDevice(in1, f, rc)
+
+				Expect(dev.GetDriver()).To(Equal("mlx5_core"))
+				Expect(dev.GetNetName()).To(Equal(""))
+				Expect(dev.GetLinkType()).To(Equal(""))
+				Expect(dev.GetEnvVal()).To(Equal("0000:00:00.1"))
+				Expect(dev.GetDeviceSpecs()).To(HaveLen(2)) // 2x Rdma devs
+				Expect(dev.GetAPIDevice().Topology.Nodes[0].ID).To(Equal(int64(0)))
+				Expect(dev.GetNumaInfo()).To(Equal("0"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("but not otherwise", func() {
+				defer fs.Use()()
+				defer utils.UseFakeLinks()()
+				dev, err := netdevice.NewPciNetDevice(in2, f, rc)
+
+				Expect(dev.GetDriver()).To(Equal("mlx5_core"))
+				Expect(dev.GetNetName()).To(Equal("eth1"))
+				Expect(dev.GetEnvVal()).To(Equal("0000:00:00.2"))
+				Expect(dev.GetDeviceSpecs()).To(HaveLen(0))
+				Expect(dev.GetLinkType()).To(Equal("fakeLinkType"))
+				Expect(dev.GetAPIDevice().Topology.Nodes[0].ID).To(Equal(int64(0)))
+				Expect(dev.GetNumaInfo()).To(Equal("0"))
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})

--- a/pkg/resources/genericInfoProvider.go
+++ b/pkg/resources/genericInfoProvider.go
@@ -20,24 +20,27 @@ import (
 )
 
 type genericInfoProvider struct {
+	pciAddr string
 }
 
 // NewGenericInfoProvider instantiate a generic DeviceInfoProvider
-func NewGenericInfoProvider() types.DeviceInfoProvider {
-	return &genericInfoProvider{}
+func NewGenericInfoProvider(pciAddr string) types.DeviceInfoProvider {
+	return &genericInfoProvider{
+		pciAddr: pciAddr,
+	}
 }
 
-func (rp *genericInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rp *genericInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
 	// NO device file, send empty DeviceSpec map
 	return devSpecs
 }
 
-func (rp *genericInfoProvider) GetEnvVal(pciAddr string) string {
-	return pciAddr
+func (rp *genericInfoProvider) GetEnvVal() string {
+	return rp.pciAddr
 }
 
-func (rp *genericInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rp *genericInfoProvider) GetMounts() []*pluginapi.Mount {
 	mounts := make([]*pluginapi.Mount, 0)
 	return mounts
 }

--- a/pkg/resources/genericInfoProvider.go
+++ b/pkg/resources/genericInfoProvider.go
@@ -19,25 +19,25 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
-type genericResource struct {
+type genericInfoProvider struct {
 }
 
-// NewGenericResource instantiate a generic DeviceInfoProvider
-func NewGenericResource() types.DeviceInfoProvider {
-	return &genericResource{}
+// NewGenericInfoProvider instantiate a generic DeviceInfoProvider
+func NewGenericInfoProvider() types.DeviceInfoProvider {
+	return &genericInfoProvider{}
 }
 
-func (rp *genericResource) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rp *genericInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
 	// NO device file, send empty DeviceSpec map
 	return devSpecs
 }
 
-func (rp *genericResource) GetEnvVal(pciAddr string) string {
+func (rp *genericInfoProvider) GetEnvVal(pciAddr string) string {
 	return pciAddr
 }
 
-func (rp *genericResource) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rp *genericInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
 	mounts := make([]*pluginapi.Mount, 0)
 	return mounts
 }

--- a/pkg/resources/genericInfoProvider_test.go
+++ b/pkg/resources/genericInfoProvider_test.go
@@ -12,7 +12,7 @@ var _ = Describe("genericInfoProvider", func() {
 	Describe("creating new genericInfoProvider", func() {
 		var pool types.DeviceInfoProvider
 		BeforeEach(func() {
-			pool = resources.NewGenericInfoProvider()
+			pool = resources.NewGenericInfoProvider("fakePCIAddr")
 		})
 		It("should return valid genericInfoProvider object", func() {
 			Expect(pool).NotTo(Equal(nil))
@@ -21,14 +21,14 @@ var _ = Describe("genericInfoProvider", func() {
 	})
 	Describe("getting mounts", func() {
 		It("should always return an empty array", func() {
-			pool := resources.NewGenericInfoProvider()
-			Expect(pool.GetMounts("fakePCIAddr")).To(BeEmpty())
+			pool := resources.NewGenericInfoProvider("fakePCIAddr")
+			Expect(pool.GetMounts()).To(BeEmpty())
 		})
 	})
 	Describe("getting device specs", func() {
 		It("should always return an empty map", func() {
-			pool := resources.NewGenericInfoProvider()
-			Expect(pool.GetDeviceSpecs("fakePCIAddr")).To(BeEmpty())
+			pool := resources.NewGenericInfoProvider("fakePCIAddr")
+			Expect(pool.GetDeviceSpecs()).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/resources/genericInfoProvider_test.go
+++ b/pkg/resources/genericInfoProvider_test.go
@@ -8,26 +8,26 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("genericResource", func() {
-	Describe("creating new genericResource", func() {
+var _ = Describe("genericInfoProvider", func() {
+	Describe("creating new genericInfoProvider", func() {
 		var pool types.DeviceInfoProvider
 		BeforeEach(func() {
-			pool = resources.NewGenericResource()
+			pool = resources.NewGenericInfoProvider()
 		})
-		It("should return valid genericResource object", func() {
+		It("should return valid genericInfoProvider object", func() {
 			Expect(pool).NotTo(Equal(nil))
-			// FIXME: Expect(reflect.TypeOf(pool)).To(Equal(reflect.TypeOf(&genericResource{})))
+			// FIXME: Expect(reflect.TypeOf(pool)).To(Equal(reflect.TypeOf(&genericInfoProvider{})))
 		})
 	})
 	Describe("getting mounts", func() {
 		It("should always return an empty array", func() {
-			pool := resources.NewGenericResource()
+			pool := resources.NewGenericInfoProvider()
 			Expect(pool.GetMounts("fakePCIAddr")).To(BeEmpty())
 		})
 	})
 	Describe("getting device specs", func() {
 		It("should always return an empty map", func() {
-			pool := resources.NewGenericResource()
+			pool := resources.NewGenericInfoProvider()
 			Expect(pool.GetDeviceSpecs("fakePCIAddr")).To(BeEmpty())
 		})
 	})

--- a/pkg/resources/pciDevice.go
+++ b/pkg/resources/pciDevice.go
@@ -30,11 +30,9 @@ type pciDevice struct {
 	vendor        string
 	product       string
 	vfID          int
-	env           string
 	numa          string
 	apiDevice     *pluginapi.Device
-	deviceSpecs   []*pluginapi.DeviceSpec
-	mounts        []*pluginapi.Mount
+	infoProviders []types.DeviceInfoProvider
 }
 
 // Convert NUMA node number to string.
@@ -47,7 +45,9 @@ func nodeToStr(nodeNum int) string {
 }
 
 // NewPciDevice returns an instance of PciDevice interface
-func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory) (types.PciDevice, error) {
+// A list of DeviceInfoProviders can be set externally.
+// If empty, the default driver-based selection provided by ResourceFactory will be used
+func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, infoProviders []types.DeviceInfoProvider) (types.PciDevice, error) {
 
 	pciAddr := dev.Address
 
@@ -68,12 +68,11 @@ func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory) (types.Pci
 		return nil, err
 	}
 
-	// Get Device file info (e.g., uio, vfio specific)
-	// Get DeviceInfoProvider using device driver
-	infoProvider := rFactory.GetInfoProvider(driverName)
-	dSpecs := infoProvider.GetDeviceSpecs(pciAddr)
-	mnt := infoProvider.GetMounts(pciAddr)
-	env := infoProvider.GetEnvVal(pciAddr)
+	// Use the default Information Provided if not
+	if len(infoProviders) == 0 {
+		infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(driverName))
+	}
+
 	nodeNum := utils.GetDevNode(pciAddr)
 	apiDevice := &pluginapi.Device{
 		ID:     pciAddr,
@@ -95,9 +94,7 @@ func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory) (types.Pci
 		driver:        driverName,
 		vfID:          vfID,
 		apiDevice:     apiDevice,
-		deviceSpecs:   dSpecs,
-		mounts:        mnt,
-		env:           env,
+		infoProviders: infoProviders,
 		numa:          nodeToStr(nodeNum),
 	}, nil
 }
@@ -131,15 +128,27 @@ func (pd *pciDevice) GetSubClass() string {
 }
 
 func (pd *pciDevice) GetDeviceSpecs() []*pluginapi.DeviceSpec {
-	return pd.deviceSpecs
+	dSpecs := make([]*pluginapi.DeviceSpec, 0)
+	for _, infoProvider := range pd.infoProviders {
+		dSpecs = append(dSpecs, infoProvider.GetDeviceSpecs(pd.basePciDevice.Address)...)
+	}
+
+	return dSpecs
 }
 
 func (pd *pciDevice) GetEnvVal() string {
-	return pd.env
+	// Currently Device Plugin does not support returning multiple Env Vars
+	// so we use the value provided by the first InfoProvider.
+	return pd.infoProviders[0].GetEnvVal(pd.basePciDevice.Address)
 }
 
 func (pd *pciDevice) GetMounts() []*pluginapi.Mount {
-	return pd.mounts
+	mnt := make([]*pluginapi.Mount, 0)
+	for _, infoProvider := range pd.infoProviders {
+		mnt = append(mnt, infoProvider.GetMounts(pd.basePciDevice.Address)...)
+	}
+
+	return mnt
 }
 
 func (pd *pciDevice) GetAPIDevice() *pluginapi.Device {

--- a/pkg/resources/pciDevice.go
+++ b/pkg/resources/pciDevice.go
@@ -70,7 +70,7 @@ func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, infoProvid
 
 	// Use the default Information Provided if not
 	if len(infoProviders) == 0 {
-		infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(driverName))
+		infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(pciAddr, driverName))
 	}
 
 	nodeNum := utils.GetDevNode(pciAddr)
@@ -130,7 +130,7 @@ func (pd *pciDevice) GetSubClass() string {
 func (pd *pciDevice) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	dSpecs := make([]*pluginapi.DeviceSpec, 0)
 	for _, infoProvider := range pd.infoProviders {
-		dSpecs = append(dSpecs, infoProvider.GetDeviceSpecs(pd.basePciDevice.Address)...)
+		dSpecs = append(dSpecs, infoProvider.GetDeviceSpecs()...)
 	}
 
 	return dSpecs
@@ -139,13 +139,13 @@ func (pd *pciDevice) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 func (pd *pciDevice) GetEnvVal() string {
 	// Currently Device Plugin does not support returning multiple Env Vars
 	// so we use the value provided by the first InfoProvider.
-	return pd.infoProviders[0].GetEnvVal(pd.basePciDevice.Address)
+	return pd.infoProviders[0].GetEnvVal()
 }
 
 func (pd *pciDevice) GetMounts() []*pluginapi.Mount {
 	mnt := make([]*pluginapi.Mount, 0)
 	for _, infoProvider := range pd.infoProviders {
-		mnt = append(mnt, infoProvider.GetMounts(pd.basePciDevice.Address)...)
+		mnt = append(mnt, infoProvider.GetMounts()...)
 	}
 
 	return mnt

--- a/pkg/resources/uioInfoProvider.go
+++ b/pkg/resources/uioInfoProvider.go
@@ -21,42 +21,26 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
-/*
-	vfioResource extends resourcePool and overrides:
-	GetDeviceSpecs(),
-	GetEnvs()
-	GetMounts()
-*/
-type vfioResource struct {
-	vfioMount string
+type uioInfoProvider struct {
 }
 
-// NewVfioResource create instance of VFIO DeviceInfoProvider
-func NewVfioResource() types.DeviceInfoProvider {
-
-	return &vfioResource{
-		vfioMount: "/dev/vfio/vfio",
-	}
-
+// NewUioInfoProvider return instance of uio DeviceInfoProvider
+func NewUioInfoProvider() types.DeviceInfoProvider {
+	return &uioInfoProvider{}
 }
 
 // *****************************************************************
 /* DeviceInfoProvider Interface */
-func (rp *vfioResource) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rp *uioInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
-	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
-		HostPath:      rp.vfioMount,
-		ContainerPath: rp.vfioMount,
-		Permissions:   "mrw",
-	})
 
-	vfioDevHost, vfioDevContainer, err := utils.GetVFIODeviceFile(pciAddr)
+	uioDev, err := utils.GetUIODeviceFile(pciAddr)
 	if err != nil {
-		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s, %s", pciAddr, err.Error())
+		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s", pciAddr)
 	} else {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
-			HostPath:      vfioDevHost,
-			ContainerPath: vfioDevContainer,
+			HostPath:      uioDev,
+			ContainerPath: uioDev,
 			Permissions:   "mrw",
 		})
 	}
@@ -64,11 +48,11 @@ func (rp *vfioResource) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
 	return devSpecs
 }
 
-func (rp *vfioResource) GetEnvVal(pciAddr string) string {
+func (rp *uioInfoProvider) GetEnvVal(pciAddr string) string {
 	return pciAddr
 }
 
-func (rp *vfioResource) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rp *uioInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
 	mounts := make([]*pluginapi.Mount, 0)
 	return mounts
 }

--- a/pkg/resources/uioInfoProvider.go
+++ b/pkg/resources/uioInfoProvider.go
@@ -22,21 +22,24 @@ import (
 )
 
 type uioInfoProvider struct {
+	pciAddr string
 }
 
 // NewUioInfoProvider return instance of uio DeviceInfoProvider
-func NewUioInfoProvider() types.DeviceInfoProvider {
-	return &uioInfoProvider{}
+func NewUioInfoProvider(pciAddr string) types.DeviceInfoProvider {
+	return &uioInfoProvider{
+		pciAddr: pciAddr,
+	}
 }
 
 // *****************************************************************
 /* DeviceInfoProvider Interface */
-func (rp *uioInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rp *uioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
 
-	uioDev, err := utils.GetUIODeviceFile(pciAddr)
+	uioDev, err := utils.GetUIODeviceFile(rp.pciAddr)
 	if err != nil {
-		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s", pciAddr)
+		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s", rp.pciAddr)
 	} else {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 			HostPath:      uioDev,
@@ -48,11 +51,11 @@ func (rp *uioInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpe
 	return devSpecs
 }
 
-func (rp *uioInfoProvider) GetEnvVal(pciAddr string) string {
-	return pciAddr
+func (rp *uioInfoProvider) GetEnvVal() string {
+	return rp.pciAddr
 }
 
-func (rp *uioInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rp *uioInfoProvider) GetMounts() []*pluginapi.Mount {
 	mounts := make([]*pluginapi.Mount, 0)
 	return mounts
 }

--- a/pkg/resources/uioInfoProvider_test.go
+++ b/pkg/resources/uioInfoProvider_test.go
@@ -16,18 +16,18 @@ var _ = Describe("UioPool", func() {
 	Describe("creating new UIO resource pool", func() {
 		var uioPool types.DeviceInfoProvider
 		BeforeEach(func() {
-			uioPool = resources.NewUioResource()
+			uioPool = resources.NewUioInfoProvider()
 		})
-		It("should return valid uioResource object", func() {
+		It("should return valid uioInfoProvider object", func() {
 			Expect(uioPool).NotTo(Equal(nil))
-			// FIXME: Expect(reflect.TypeOf(uioPool)).To(Equal(reflect.TypeOf(&uioResource{})))
+			// FIXME: Expect(reflect.TypeOf(uioPool)).To(Equal(reflect.TypeOf(&uioInfoProvider{})))
 		})
 	})
 	DescribeTable("getting device specs",
 		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
 			defer fs.Use()()
 
-			pool := resources.NewUioResource()
+			pool := resources.NewUioInfoProvider()
 			specs := pool.GetDeviceSpecs(pciAddr)
 			Expect(specs).To(ConsistOf(expected))
 		},
@@ -46,7 +46,7 @@ var _ = Describe("UioPool", func() {
 	)
 	Describe("getting mounts", func() {
 		It("should always return empty array of mounts", func() {
-			pool := resources.NewUioResource()
+			pool := resources.NewUioInfoProvider()
 			result := pool.GetMounts("fakePCIAddr")
 			Expect(result).To(BeEmpty())
 		})
@@ -54,7 +54,7 @@ var _ = Describe("UioPool", func() {
 	Describe("getting env val", func() {
 		It("should always return passed PCI address", func() {
 			in := "00:02.0"
-			pool := resources.NewUioResource()
+			pool := resources.NewUioInfoProvider()
 			out := pool.GetEnvVal(in)
 			Expect(out).To(Equal(in))
 		})

--- a/pkg/resources/uioInfoProvider_test.go
+++ b/pkg/resources/uioInfoProvider_test.go
@@ -16,7 +16,7 @@ var _ = Describe("UioPool", func() {
 	Describe("creating new UIO resource pool", func() {
 		var uioPool types.DeviceInfoProvider
 		BeforeEach(func() {
-			uioPool = resources.NewUioInfoProvider()
+			uioPool = resources.NewUioInfoProvider("fakePCIAddr")
 		})
 		It("should return valid uioInfoProvider object", func() {
 			Expect(uioPool).NotTo(Equal(nil))
@@ -27,8 +27,8 @@ var _ = Describe("UioPool", func() {
 		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
 			defer fs.Use()()
 
-			pool := resources.NewUioInfoProvider()
-			specs := pool.GetDeviceSpecs(pciAddr)
+			pool := resources.NewUioInfoProvider(pciAddr)
+			specs := pool.GetDeviceSpecs()
 			Expect(specs).To(ConsistOf(expected))
 		},
 		Entry("empty", &utils.FakeFilesystem{}, "", []*pluginapi.DeviceSpec{}),
@@ -46,16 +46,16 @@ var _ = Describe("UioPool", func() {
 	)
 	Describe("getting mounts", func() {
 		It("should always return empty array of mounts", func() {
-			pool := resources.NewUioInfoProvider()
-			result := pool.GetMounts("fakePCIAddr")
+			pool := resources.NewUioInfoProvider("fakePCIAddr")
+			result := pool.GetMounts()
 			Expect(result).To(BeEmpty())
 		})
 	})
 	Describe("getting env val", func() {
 		It("should always return passed PCI address", func() {
 			in := "00:02.0"
-			pool := resources.NewUioInfoProvider()
-			out := pool.GetEnvVal(in)
+			pool := resources.NewUioInfoProvider(in)
+			out := pool.GetEnvVal()
 			Expect(out).To(Equal(in))
 		})
 	})

--- a/pkg/resources/vfioInfoProvider.go
+++ b/pkg/resources/vfioInfoProvider.go
@@ -25,13 +25,15 @@ import (
    vfioInfoProvider implements DeviceInfoProvider
 */
 type vfioInfoProvider struct {
+	pciAddr   string
 	vfioMount string
 }
 
 // NewVfioInfoProvider create instance of VFIO DeviceInfoProvider
-func NewVfioInfoProvider() types.DeviceInfoProvider {
+func NewVfioInfoProvider(pciAddr string) types.DeviceInfoProvider {
 
 	return &vfioInfoProvider{
+		pciAddr:   pciAddr,
 		vfioMount: "/dev/vfio/vfio",
 	}
 
@@ -39,7 +41,7 @@ func NewVfioInfoProvider() types.DeviceInfoProvider {
 
 // *****************************************************************
 /* DeviceInfoProvider Interface */
-func (rp *vfioInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec {
+func (rp *vfioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
 	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 		HostPath:      rp.vfioMount,
@@ -47,9 +49,9 @@ func (rp *vfioInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSp
 		Permissions:   "mrw",
 	})
 
-	vfioDevHost, vfioDevContainer, err := utils.GetVFIODeviceFile(pciAddr)
+	vfioDevHost, vfioDevContainer, err := utils.GetVFIODeviceFile(rp.pciAddr)
 	if err != nil {
-		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s, %s", pciAddr, err.Error())
+		glog.Errorf("GetDeviceSpecs(): error getting vfio device file for device: %s, %s", rp.pciAddr, err.Error())
 	} else {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 			HostPath:      vfioDevHost,
@@ -61,11 +63,11 @@ func (rp *vfioInfoProvider) GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSp
 	return devSpecs
 }
 
-func (rp *vfioInfoProvider) GetEnvVal(pciAddr string) string {
-	return pciAddr
+func (rp *vfioInfoProvider) GetEnvVal() string {
+	return rp.pciAddr
 }
 
-func (rp *vfioInfoProvider) GetMounts(pciAddr string) []*pluginapi.Mount {
+func (rp *vfioInfoProvider) GetMounts() []*pluginapi.Mount {
 	mounts := make([]*pluginapi.Mount, 0)
 	return mounts
 }

--- a/pkg/resources/vfioInfoProvider_test.go
+++ b/pkg/resources/vfioInfoProvider_test.go
@@ -16,7 +16,7 @@ var _ = Describe("VfioPool", func() {
 	Describe("creating new VFIO resource", func() {
 		var vfioPool types.DeviceInfoProvider
 		BeforeEach(func() {
-			vfioPool = resources.NewVfioInfoProvider()
+			vfioPool = resources.NewVfioInfoProvider("fakePCIAddr")
 		})
 		It("should return valid vfioInfoProvider object", func() {
 			Expect(vfioPool).NotTo(Equal(nil))
@@ -27,8 +27,8 @@ var _ = Describe("VfioPool", func() {
 		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
 			defer fs.Use()()
 
-			pool := resources.NewVfioInfoProvider()
-			specs := pool.GetDeviceSpecs(pciAddr)
+			pool := resources.NewVfioInfoProvider(pciAddr)
+			specs := pool.GetDeviceSpecs()
 			Expect(specs).To(ConsistOf(expected))
 		},
 		Entry("empty and returning default common vfio device file only",
@@ -56,16 +56,16 @@ var _ = Describe("VfioPool", func() {
 	)
 	Describe("getting mounts", func() {
 		It("should always return empty array of mounts", func() {
-			pool := resources.NewVfioInfoProvider()
-			result := pool.GetMounts("fakeAddr")
+			pool := resources.NewVfioInfoProvider("fakeAddr")
+			result := pool.GetMounts()
 			Expect(result).To(BeEmpty())
 		})
 	})
 	Describe("getting env val", func() {
 		It("should always return passed PCI address", func() {
 			in := "00:02.0"
-			pool := resources.NewVfioInfoProvider()
-			out := pool.GetEnvVal(in)
+			pool := resources.NewVfioInfoProvider(in)
+			out := pool.GetEnvVal()
 			Expect(out).To(Equal(in))
 		})
 	})

--- a/pkg/resources/vfioInfoProvider_test.go
+++ b/pkg/resources/vfioInfoProvider_test.go
@@ -16,18 +16,18 @@ var _ = Describe("VfioPool", func() {
 	Describe("creating new VFIO resource", func() {
 		var vfioPool types.DeviceInfoProvider
 		BeforeEach(func() {
-			vfioPool = resources.NewVfioResource()
+			vfioPool = resources.NewVfioInfoProvider()
 		})
-		It("should return valid vfioResource object", func() {
+		It("should return valid vfioInfoProvider object", func() {
 			Expect(vfioPool).NotTo(Equal(nil))
-			// FIXME: Expect(reflect.TypeOf(vfioPool)).To(Equal(reflect.TypeOf(&vfioResource{})))
+			// FIXME: Expect(reflect.TypeOf(vfioPool)).To(Equal(reflect.TypeOf(&vfioInfoProvider{})))
 		})
 	})
 	DescribeTable("GetDeviceSpecs",
 		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
 			defer fs.Use()()
 
-			pool := resources.NewVfioResource()
+			pool := resources.NewVfioInfoProvider()
 			specs := pool.GetDeviceSpecs(pciAddr)
 			Expect(specs).To(ConsistOf(expected))
 		},
@@ -56,7 +56,7 @@ var _ = Describe("VfioPool", func() {
 	)
 	Describe("getting mounts", func() {
 		It("should always return empty array of mounts", func() {
-			pool := resources.NewVfioResource()
+			pool := resources.NewVfioInfoProvider()
 			result := pool.GetMounts("fakeAddr")
 			Expect(result).To(BeEmpty())
 		})
@@ -64,7 +64,7 @@ var _ = Describe("VfioPool", func() {
 	Describe("getting env val", func() {
 		It("should always return passed PCI address", func() {
 			in := "00:02.0"
-			pool := resources.NewVfioResource()
+			pool := resources.NewVfioInfoProvider()
 			out := pool.GetEnvVal(in)
 			Expect(out).To(Equal(in))
 		})

--- a/pkg/types/mocks/DeviceInfoProvider.go
+++ b/pkg/types/mocks/DeviceInfoProvider.go
@@ -13,13 +13,13 @@ type DeviceInfoProvider struct {
 	mock.Mock
 }
 
-// GetDeviceSpecs provides a mock function with given fields: pciAddr
-func (_m *DeviceInfoProvider) GetDeviceSpecs(pciAddr string) []*v1beta1.DeviceSpec {
-	ret := _m.Called(pciAddr)
+// GetDeviceSpecs provides a mock function with given fields:
+func (_m *DeviceInfoProvider) GetDeviceSpecs() []*v1beta1.DeviceSpec {
+	ret := _m.Called()
 
 	var r0 []*v1beta1.DeviceSpec
-	if rf, ok := ret.Get(0).(func(string) []*v1beta1.DeviceSpec); ok {
-		r0 = rf(pciAddr)
+	if rf, ok := ret.Get(0).(func() []*v1beta1.DeviceSpec); ok {
+		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1beta1.DeviceSpec)
@@ -29,13 +29,13 @@ func (_m *DeviceInfoProvider) GetDeviceSpecs(pciAddr string) []*v1beta1.DeviceSp
 	return r0
 }
 
-// GetEnvVal provides a mock function with given fields: pciAddr
-func (_m *DeviceInfoProvider) GetEnvVal(pciAddr string) string {
-	ret := _m.Called(pciAddr)
+// GetEnvVal provides a mock function with given fields:
+func (_m *DeviceInfoProvider) GetEnvVal() string {
+	ret := _m.Called()
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(pciAddr)
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
 	}
@@ -43,13 +43,13 @@ func (_m *DeviceInfoProvider) GetEnvVal(pciAddr string) string {
 	return r0
 }
 
-// GetMounts provides a mock function with given fields: pciAddr
-func (_m *DeviceInfoProvider) GetMounts(pciAddr string) []*v1beta1.Mount {
-	ret := _m.Called(pciAddr)
+// GetMounts provides a mock function with given fields:
+func (_m *DeviceInfoProvider) GetMounts() []*v1beta1.Mount {
+	ret := _m.Called()
 
 	var r0 []*v1beta1.Mount
-	if rf, ok := ret.Get(0).(func(string) []*v1beta1.Mount); ok {
-		r0 = rf(pciAddr)
+	if rf, ok := ret.Get(0).(func() []*v1beta1.Mount); ok {
+		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1beta1.Mount)

--- a/pkg/types/mocks/ResourceFactory.go
+++ b/pkg/types/mocks/ResourceFactory.go
@@ -12,6 +12,22 @@ type ResourceFactory struct {
 	mock.Mock
 }
 
+// GetDefaultInfoProvider provides a mock function with given fields: _a0
+func (_m *ResourceFactory) GetDefaultInfoProvider(_a0 string) types.DeviceInfoProvider {
+	ret := _m.Called(_a0)
+
+	var r0 types.DeviceInfoProvider
+	if rf, ok := ret.Get(0).(func(string) types.DeviceInfoProvider); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.DeviceInfoProvider)
+		}
+	}
+
+	return r0
+}
+
 // GetDeviceFilter provides a mock function with given fields: _a0
 func (_m *ResourceFactory) GetDeviceFilter(_a0 *types.ResourceConfig) (interface{}, error) {
 	ret := _m.Called(_a0)
@@ -45,22 +61,6 @@ func (_m *ResourceFactory) GetDeviceProvider(_a0 types.DeviceType) types.DeviceP
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.DeviceProvider)
-		}
-	}
-
-	return r0
-}
-
-// GetInfoProvider provides a mock function with given fields: _a0
-func (_m *ResourceFactory) GetInfoProvider(_a0 string) types.DeviceInfoProvider {
-	ret := _m.Called(_a0)
-
-	var r0 types.DeviceInfoProvider
-	if rf, ok := ret.Get(0).(func(string) types.DeviceInfoProvider); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(types.DeviceInfoProvider)
 		}
 	}
 

--- a/pkg/types/mocks/ResourceFactory.go
+++ b/pkg/types/mocks/ResourceFactory.go
@@ -12,13 +12,13 @@ type ResourceFactory struct {
 	mock.Mock
 }
 
-// GetDefaultInfoProvider provides a mock function with given fields: _a0
-func (_m *ResourceFactory) GetDefaultInfoProvider(_a0 string) types.DeviceInfoProvider {
-	ret := _m.Called(_a0)
+// GetDefaultInfoProvider provides a mock function with given fields: _a0, _a1
+func (_m *ResourceFactory) GetDefaultInfoProvider(_a0 string, _a1 string) types.DeviceInfoProvider {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.DeviceInfoProvider
-	if rf, ok := ret.Get(0).(func(string) types.DeviceInfoProvider); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(string, string) types.DeviceInfoProvider); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.DeviceInfoProvider)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -125,7 +125,7 @@ type ResourceServer interface {
 // ResourceFactory is an interface to get instances of ResourcePool and ResouceServer
 type ResourceFactory interface {
 	GetResourceServer(ResourcePool) (ResourceServer, error)
-	GetDefaultInfoProvider(string) DeviceInfoProvider
+	GetDefaultInfoProvider(string, string) DeviceInfoProvider
 	GetSelector(string, []string) (DeviceSelector, error)
 	GetResourcePool(rc *ResourceConfig, deviceList []PciDevice) (ResourcePool, error)
 	GetRdmaSpec(string) RdmaSpec
@@ -195,9 +195,9 @@ type AccelDevice interface {
 
 // DeviceInfoProvider is an interface to get Device Plugin API specific device information
 type DeviceInfoProvider interface {
-	GetDeviceSpecs(pciAddr string) []*pluginapi.DeviceSpec
-	GetEnvVal(pciAddr string) string
-	GetMounts(pciAddr string) []*pluginapi.Mount
+	GetDeviceSpecs() []*pluginapi.DeviceSpec
+	GetEnvVal() string
+	GetMounts() []*pluginapi.Mount
 }
 
 // DeviceSelector provides an interface for filtering a list of devices

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -125,7 +125,7 @@ type ResourceServer interface {
 // ResourceFactory is an interface to get instances of ResourcePool and ResouceServer
 type ResourceFactory interface {
 	GetResourceServer(ResourcePool) (ResourceServer, error)
-	GetInfoProvider(string) DeviceInfoProvider
+	GetDefaultInfoProvider(string) DeviceInfoProvider
 	GetSelector(string, []string) (DeviceSelector, error)
 	GetResourcePool(rc *ResourceConfig, deviceList []PciDevice) (ResourcePool, error)
 	GetRdmaSpec(string) RdmaSpec


### PR DESCRIPTION
Currently, the generation of DeviceSpecs is done in two different places.

First, the PciNetDevice is created, and it may create alternative deviceSpecs objects (e.g: `RdmaSpecs`) that are stored within `PciNetDevice`. Then the underlying PciDevice is created and, based on the driver that is bound to the device, an implementation of the  `DeviceInfoProvider` interface is created, which provides more DeviceSpecs.

After, when Allocate() is called,  the `NetResourcePool` has some logic to append these deviceSpecs.

This imposes a limitation on how flexibly we can choose what DeviceSpecs are exposed (must be determined by the driver) and fosters ad-hoc DeviceSpec-appending logic (see how vhostNet DeviceSpec was added).

In order to improve this, I'd like to propose the generalization of DeviceInfoProviders for deviceSpec selection. This PR first allows the PciDevice to be built based on a list of DeviceInfoProviders. The appending logic is moved to the pciDevice getters (e.g: `pciDevice.GetDeviceSpec()`) and the selection of what DeviceInfoProviders to pass is DeviceType specific.

Finally, Rdma and VhostNet deviceSpec appending are implemented using DeviceInfoProviders.
Note that the `DeviceInfoProvider.getDeviceSpecs()` is called after the device have been filtered. Therefore, it can generate errors if it fails to generate the DeviceSpecs correctly.
