### PR TITLE
entrypoint: use exec to run Device Plugin

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -67,4 +67,4 @@ if [ "$CONFIG_FILE" != "" ]; then
     CLI_PARAMS="$CLI_PARAMS --config-file $CONFIG_FILE"
 fi
 
-$SRIOV_DP_SYS_BINARY_DIR/sriovdp $CLI_PARAMS
+exec $SRIOV_DP_SYS_BINARY_DIR/sriovdp $CLI_PARAMS


### PR DESCRIPTION
On Pod / DaemonSet termination, Kubernetes sends SIGTERM to the first
process (pid 1).

In order to ensure the SR-IOV Device Plugin daemon receives the signal
and it can gracefully clean up, use "exec" in the entrypoint script.

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>