### PR TITLE
Remove hostPID cap from deployment examples

### DIFF
--- a/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
@@ -22,7 +22,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:
@@ -78,7 +77,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: ppc64le
       tolerations:

--- a/deployments/k8s-v1.16/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.16/sriovdp-daemonset.yaml
@@ -26,7 +26,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:
@@ -86,7 +85,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: ppc64le
       tolerations:
@@ -145,7 +143,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: arm64
       tolerations:

--- a/docs/config-file/README.md
+++ b/docs/config-file/README.md
@@ -45,7 +45,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:


### PR DESCRIPTION
This commit removes the HostPID cap from deployment
examples as it is not needed for proper operation
of device plugin.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>