### PR TITLE
Specify image url repo explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GOBIN
 # Docker
 IMAGEDIR=$(BASE)/images
 DOCKERFILE?=$(CURDIR)/images/Dockerfile
-TAG=nfvpe/sriov-device-plugin
+TAG=docker.io/nfvpe/sriov-device-plugin
 # Accept proxy settings for docker 
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin:v3.3
+        image: docker.io/nfvpe/sriov-device-plugin:v3.3
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp
@@ -86,7 +86,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin:ppc64le
+        image: docker.io/nfvpe/sriov-device-plugin:ppc64le
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/deployments/k8s-v1.16/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.16/sriovdp-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin:v3.3
+        image: docker.io/nfvpe/sriov-device-plugin:v3.3
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp
@@ -100,7 +100,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin:ppc64le
+        image: docker.io/nfvpe/sriov-device-plugin:ppc64le
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/docs/config-file/README.md
+++ b/docs/config-file/README.md
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin
+        image: docker.io/nfvpe/sriov-device-plugin
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/images/README.md
+++ b/images/README.md
@@ -5,7 +5,7 @@ This is used for distribution of SR-IOV Device Plugin binary in a Docker image.
 Typically you'd build this from the root of your SR-IOV network device plugin clone, and you'd set the `-f` flag to specify the Dockerfile during build time. This allows the addition of the entirety of the SR-IOV network device plugin git clone as part of the Docker context. Use the `-f` flag with the root of the clone as the context (e.g. your current work directory would be root of git clone), such as:
 
 ```
-$ docker build -t nfvpe/sriov-device-plugin -f ./images/Dockerfile .
+$ docker build -t docker.io/nfvpe/sriov-device-plugin -f ./images/Dockerfile .
 ```
 You can run `make image` to build the docker image as well.
 
@@ -29,7 +29,7 @@ Note: The likely best practice here is to build your own image given the Dockerf
 Example docker run command:
 
 ```
-$ docker run -it -v /var/lib/kubelet/:/var/lib/kubelet/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash nfvpe/sriovdp
+$ docker run -it -v /var/lib/kubelet/:/var/lib/kubelet/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash docker.io/nfvpe/sriovdp
 ```
 
 Originally inspired by and is a portmanteau of the [Flannel daemonset](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml), the [Calico Daemonset](https://github.com/projectcalico/calico/blob/master/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml), and the [Calico CNI install bash script](https://github.com/projectcalico/cni-plugin/blob/be4df4db2e47aa7378b1bdf6933724bac1f348d0/k8s-install/scripts/install-cni.sh#L104-L153).


### PR DESCRIPTION
docker.io may not be the default container repository
url in some runtime configurations.

Signed-off-by: Zenghui Shi <zshi@redhat.com>