### PR TITLE
WIP: Update travis VM from Ubuntu 16.04 to 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+dist: bionic
 
 go:
   "1.13"


### PR DESCRIPTION
Test PR to check if upgrading travis VM solves make test issue with error:

```
Resource manager

/home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/cmd/sriovdp/manager_test.go:48

  discovering devices

  /home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92

    no devices [It]

    /home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Unexpected error:

        <*errors.errorString | 0xc0004c5990>: {

            s: "discoverDevices(): error getting PCI info: gzip: invalid header",

        }

        discoverDevices(): error getting PCI info: gzip: invalid header

    occurred

    /home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/cmd/sriovdp/manager_test.go:315

------------------------------ 
```
Signed-off-by: Martin Kennelly <martin.kennelly@intel.com>