### PR TITLE
WIP: Ensure PCI IDs file exists in Travis VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   #     - DOCKERFILE=images/Dockerfile.ppc64le
 
 before_install:
+  - sudo update-pciids
   - sudo apt-get update -qq
   - sudo systemctl restart docker
 


### PR DESCRIPTION
Test to try and fix error:
```
Resource manager

/home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/cmd/sriovdp/manager_test.go:48

  discovering devices

  /home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92

    no devices [It]

    /home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Unexpected error:

        <*errors.errorString | 0xc0004c5990>: {

            s: "discoverDevices(): error getting PCI info: gzip: invalid header",

        }

        discoverDevices(): error getting PCI info: gzip: invalid header

    occurred

    /home/travis/gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/.gopath/src/github.com/k8snetworkplumbingwg/sriov-network-device-plugin/cmd/sriovdp/manager_test.go:315

------------------------------
```

Fix issue with Jaypipes PCI package failing to source pci id file from
remote. This ensures it is available in well-known locations.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>