### PR TITLE
Add pci.ids file in test filesystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
 before_install:
   - sudo apt-get update -qq
+  - sudo apt-get install hwdata -yq
   - sudo systemctl restart docker
 
 script:

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -37,6 +37,23 @@ func (fs *FakeFilesystem) Use() func() {
 			panic(fmt.Errorf("error creating fake file: %s", err.Error()))
 		}
 	}
+	err = os.MkdirAll(path.Join(fs.RootDir, "usr/share/hwdata"), 0755)
+	if err != nil {
+		panic(fmt.Errorf("error creating fake directory: %s", err.Error()))
+	}
+
+	// TODO: Remove writing pci.ids file once ghw is mocked
+	// This is to fix the CI failure where ghw lib fails to
+	// unzip pci.ids file downloaded from internet.
+	pciData, err := ioutil.ReadFile("/usr/share/hwdata/pci.ids")
+	if err != nil {
+		panic(fmt.Errorf("error reading file: %s", err.Error()))
+	}
+	err = ioutil.WriteFile(path.Join(fs.RootDir, "usr/share/hwdata/pci.ids"), pciData, 0644)
+	if err != nil {
+		panic(fmt.Errorf("error creating fake file: %s", err.Error()))
+	}
+
 	for link, target := range fs.Symlinks {
 		err = os.Symlink(target, path.Join(fs.RootDir, link))
 		if err != nil {


### PR DESCRIPTION
This temporarily fixes a unit test error in travis
where pci.ids doesn't exist in the fake filesystem
and ghw lib tries to download it from internet, but
fails to unzip the downloaded package header.
    
Signed-off-by: Zenghui Shi <zshi@redhat.com>