### PR TITLE
fix hadolint errors

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,24 +1,29 @@
 FROM golang:alpine3.12 as builder
 
-ADD . /usr/src/sriov-network-device-plugin
+COPY . /usr/src/sriov-network-device-plugin
 ADD images/ddptool-1.0.0.0.tar.gz /tmp/ddptool/
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
-RUN apk add --update --virtual build-dependencies build-base linux-headers && \
-    cd /usr/src/sriov-network-device-plugin && \
-    make clean && \
-    make build && \
-    cd /tmp/ddptool && make
+RUN apk add --no-cache --virtual build-dependencies build-base linux-headers
+
+WORKDIR /usr/src/sriov-network-device-plugin
+RUN make clean && \
+    make build
+
+WORKDIR /tmp/ddptool
+RUN make
 
 FROM alpine:3.12
-RUN apk add hwdata-pci
+RUN apk add --no-cache hwdata-pci
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=builder /tmp/ddptool/ddptool /usr/bin/
 WORKDIR /
 
 LABEL io.k8s.display-name="SRIOV Network Device Plugin"
 
-ADD ./images/entrypoint.sh /
+COPY ./images/entrypoint.sh /
+
+RUN rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fixed errors:
DL3020 Use COPY instead of ADD for files and folders
DL3003 Use WORKDIR to switch to a directory
DL3019 Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages
Remaining errors:
DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
(It's probably safer to not pin versions in case they aren't available in the future, which might cause the build to fail.)
DL3006 Always tag the version of an image explicitly (community discussion is required to establish which version of alpine should be used). 

Fixes #315 