### PR TITLE
Set alpine to specific version to fix DDPTool build

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:alpine3.12 as builder
 
 ADD . /usr/src/sriov-network-device-plugin
 ADD images/ddptool-1.0.0.0.tar.gz /tmp/ddptool/


### PR DESCRIPTION
DDPTool 1.0.0 does not build with Alpine 3.13.
Temporary fix is setting alpine container to a specific
version where DDPTool builds ok.

Fix to DDPTool itself will follow next week.