### PR TITLE
Fix alpine 3.13 APK proxy build issue

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --virtual build-dependencies build-base linux-headers && \
     make build && \
     cd /tmp/ddptool && make
 
-FROM alpine
+FROM alpine:3.12
 RUN apk add hwdata-pci
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=builder /tmp/ddptool/ddptool /usr/bin/


### PR DESCRIPTION
Alpine 3.13 set APK repositories to https instead of http.
APK does not work with https proxy because of libfetch issue.
Set alpine to 3.12 until issue is resolved.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>

See: 
https://github.com/alpinelinux/docker-alpine/issues/136
https://github.com/alpinelinux/docker-alpine/issues/98
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=220468

Partially fixes #315