### PR TITLE
Fix auto invite to NPWG slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,6 @@ $ git checkout -b dev/some-topic-branch
 > We encourage contributor to test SRIOV Network Device plugin with various NICs to check the compatibility.
 >
 ## Contact Us
-- #General channel on [NPWG](https://npwg-team.slack.com/) Slack
+- #General channel on [NPWG](https://npwg-team.slack.com/) Slack. Request an invite to NPWG slack [here](https://intel-corp.herokuapp.com/).
 - Feel free to post GitHub issues and PRs for review
 - Attend either K8s Network & Resource mangement or Additional K8s Network & Resource management meetings


### PR DESCRIPTION
Re-adding NPWG slack auto invite mechanism. Non-Intel users
need mechanism to join NPWG slack.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>

I misunderstood slacks invite mechanism for non-Intel users. Non-Intel users require invite. Re-adding invite mechanism. 

I attempted to change URL of invite mechanism but failed. Slack only grands auto invite rights to enterprise workspaces. See here outsideris/slack-invite-automation#146
Currently, the intel-corp.heroku.com app relies on slacks legacy token mechanism to accomplish this. This will fail in the future when legacy tokens are deprecated. I think this should be discussed at NPWG level but in the mean time, I propose re-adding auto invite mechanism. 