### PR TITLE
set memory/cpu requests/limits

### DIFF
--- a/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
@@ -38,6 +38,13 @@ spec:
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/
@@ -93,6 +100,13 @@ spec:
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/

--- a/deployments/k8s-v1.16/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.16/sriovdp-daemonset.yaml
@@ -42,6 +42,13 @@ spec:
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/
@@ -107,6 +114,13 @@ spec:
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/
@@ -173,6 +187,13 @@ spec:
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/


### PR DESCRIPTION
Containers without memory limits are more likely to be
terminated when the node runs out of memory. Ring fencing
memory ensures our service is isolated.

Containers without cpu limits can exceed the capacity of the
node and affect performance of the host and other containers.

CPU/memory information was gathered from "docker stats ..".
~20mb is normal operating memory footprint.

There is also DOS considerations if our service is compromised.
Signed-off-by: Martin Kennelly <martin.kennelly@intel.com>