### PR TITLE
Upgrade containernetworking/cni dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,8 @@ require (
 	k8s.io/kubelet v0.18.1
 )
 
-replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+replace (
+	github.com/containernetworking/cni => github.com/containernetworking/cni v0.8.1
+	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+)
+

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK31EJ9FzE=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
+github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
While working with Device Plugin SNYK scan reported vulnerability in containernetworking/cni module, therefore decided to update the module.

Vulnerability's details below:

**HIGH SEVERITY
Directory Traversal** 

Vulnerable module:	github.com/containernetworking/cni/pkg/invoke
Introduced through:	github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils@#9d213757d22d
Exploit maturity:	No known exploit
Fixed in:	0.8.1

**Detailed paths**
Introduced through: github.com/k8snetworkplumbingwg/sriov-network-device-plugin@0.0.0 › github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils@#9d213757d22d › github.com/containernetworking/cni/libcni@0.8.0 › github.com/containernetworking/cni/pkg/invoke@0.8.0

**Overview**
Affected versions of this package are vulnerable to Directory Traversal. When specifying the plugin to load in the type field in the network configuration, it is possible to use special elements such as "../" separators to reference binaries elsewhere on the system. An attacker can use this to execute other existing binaries other than the cni plugins/types such as reboot.