### PR TITLE
Make it easier for the end user to debug issues with their sriov config

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -81,7 +81,7 @@ func (rm *resourceManager) readConfig() error {
 
 	glog.Infof("raw ResourceList: %s", rawBytes)
 	if err = json.Unmarshal(rawBytes, resources); err != nil {
-		return fmt.Errorf("error unmarshalling raw bytes %v\n please make sure the config is in json format \n", err)
+		return fmt.Errorf("error unmarshalling raw bytes %v please make sure the config is in json format", err)
 	}
 
 	for i := range resources.ResourceList {

--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -79,11 +79,11 @@ func (rm *resourceManager) readConfig() error {
 
 	}
 
+	glog.Infof("raw ResourceList: %s", rawBytes)
 	if err = json.Unmarshal(rawBytes, resources); err != nil {
-		return fmt.Errorf("error unmarshalling raw bytes %v", err)
+		return fmt.Errorf("error unmarshalling raw bytes %v\n please make sure the config is in json format \n", err)
 	}
 
-	glog.Infof("raw ResourceList: %s", rawBytes)
 	for i := range resources.ResourceList {
 		conf := &resources.ResourceList[i]
 		// Validate deviceType


### PR DESCRIPTION
With this patch the config is logged before the error is returned.
When the user looks through the logs they will be able to see their config,
along with a message asking them to check if config is in json format.

Signed-off-by: John O'Loughlin <john.oloughlin@intel.com>