### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 # Tested with golangci-lint ver. 1.37
+run:
+  timeout: 3m
 linters-settings:
   depguard:
     list-type: blacklist


### PR DESCRIPTION
occasionaly it takes more than the default 1m
to perform the check in CI.

increase timeout to 3m

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>