### PR TITLE
Fix empty filteredDevices

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -120,11 +120,11 @@ func (rm *resourceManager) initServers() error {
 		if err != nil {
 			glog.Errorf("initServers(): error getting filtered devices for config %+v: %q", rc, err)
 		}
+		filteredDevices = rm.excludeAllocatedDevices(filteredDevices, deviceAllocated)
 		if len(filteredDevices) < 1 {
 			glog.Infof("no devices in device pool, skipping creating resource server for %s", rc.ResourceName)
 			continue
 		}
-		filteredDevices = rm.excludeAllocatedDevices(filteredDevices, deviceAllocated)
 		rPool, err := rm.rFactory.GetResourcePool(rc, filteredDevices)
 		if err != nil {
 			glog.Errorf("initServers(): error creating ResourcePool with config %+v: %q", rc, err)


### PR DESCRIPTION
filteredDevices may be empty when excluding allocated devices
which results in failure initializing servers:
```
I1103 07:44:28.118760 1680023 manager.go:110] Creating new ResourcePool: dpdk
I1103 07:44:28.118764 1680023 manager.go:111] DeviceType: netDevice
W1103 07:44:28.121483 1680023 manager.go:152] Cannot add PCI Address [0000:3b:0a.0]. Already allocated.
W1103 07:44:28.121494 1680023 manager.go:152] Cannot add PCI Address [0000:3b:0a.1]. Already allocated.
E1103 07:44:28.121500 1680023 manager.go:136] initServers(): error creating ResourceServer: factory: unable to get resource pool object
E1103 07:44:28.121530 1680023 main.go:68] error initializing resource servers factory: unable to get resource pool object
```

Signed-off-by: Zenghui Shi <zshi@redhat.com>