### PR TITLE
add support for vfOnly in the selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,13 @@ The "deviceType" value determines which selectors are supported for that device.
 #### Common selectors
 All device types support following common device selectors.
 
-|   Field        | Required |                Description                |         Type/Defaults          |   Example/Accepted values        |
-|----------------|----------|-------------------------------------------|--------------------------------|----------------------------------|
-| "vendors"      | N        | Target device's vendor Hex code as string | `string` list Default: `null`  | "vendors": ["8086", "15b3"]      |
-| "devices"      | N        | Target Devices' device Hex code as string | `string` list Default: `null`  | "devices": ["154c", "1889", "1018"] |
-| "drivers"      | N        | Target device driver names as string      | `string` list Default: `null`  | "drivers": ["vfio-pci"]          |
-| "pciAddresses" | N        | Target device's pci address as string     | `string` list Default: `null`  | "pciAddresses": ["0000:03:02.0"] |
+|   Field        | Required | Description                              | Type/Defaults                 | Example/Accepted values             |
+|----------------|----------|------------------------------------------|-------------------------------|-------------------------------------|
+| "vendors"      | N        | Target device's vendor Hex code as string | `string` list Default: `null` | "vendors": ["8086", "15b3"]         |
+| "devices"      | N        | Target Devices' device Hex code as string | `string` list Default: `null` | "devices": ["154c", "1889", "1018"] |
+| "drivers"      | N        | Target device driver names as string     | `string` list Default: `null` | "drivers": ["vfio-pci"]             |
+| "pciAddresses" | N        | Target device's pci address as string    | `string` list Default: `null` | "pciAddresses": ["0000:03:02.0"]    |
+| "vfOnly"       | N        | Skip PF interfaces                       | `bool` Default: `false`        | "vfOnly": true                      |
 
 
 #### Extended selectors for device type "netDevice"

--- a/pkg/accelerator/accelDeviceProvider.go
+++ b/pkg/accelerator/accelDeviceProvider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jaypipes/ghw"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 )
 
 const (
@@ -122,6 +123,17 @@ func (ap *accelDeviceProvider) GetFilteredDevices(devices []types.PciDevice, rc 
 		if selector, err := rf.GetSelector("pciAddresses", af.PciAddresses); err == nil {
 			filteredDevice = selector.Filter(filteredDevice)
 		}
+	}
+
+	if af.VfOnly {
+		vfOnlyDevices := make([]types.PciDevice, 0)
+		for _, dev := range filteredDevice {
+			if !utils.IsSriovPF(dev.GetPciAddr()) {
+				vfOnlyDevices = append(vfOnlyDevices, dev)
+			}
+		}
+
+		filteredDevice = vfOnlyDevices
 	}
 
 	// convert to []AccelDevice to []PciDevice

--- a/pkg/netdevice/netDeviceProvider.go
+++ b/pkg/netdevice/netDeviceProvider.go
@@ -209,6 +209,17 @@ func (np *netDeviceProvider) GetFilteredDevices(devices []types.PciDevice, rc *t
 		filteredDevice = rdmaDevices
 	}
 
+	if nf.VfOnly {
+		vfOnlyDevices := make([]types.PciDevice, 0)
+		for _, dev := range filteredDevice {
+			if !utils.IsSriovPF(dev.GetPciAddr()) {
+				vfOnlyDevices = append(vfOnlyDevices, dev)
+			}
+		}
+
+		filteredDevice = vfOnlyDevices
+	}
+
 	// convert to []PciNetDevice to []PciDevice
 	newDeviceList := make([]types.PciDevice, len(filteredDevice))
 	copy(newDeviceList, filteredDevice)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -87,6 +87,7 @@ type DeviceSelectors struct {
 	Devices      []string `json:"devices,omitempty"`
 	Drivers      []string `json:"drivers,omitempty"`
 	PciAddresses []string `json:"pciAddresses,omitempty"`
+	VfOnly       bool     `json:"vfOnly,omitempty"`
 }
 
 // NetDeviceSelectors contains network device related selectors fields


### PR DESCRIPTION
This commit add a new variable in the selector.

default will be false and no change in the current device plugin implementation.

When this variable will be true we will only add VFs to the pools even if the PF have 0 VFs

Signed-off-by: Sebastian Sch <sebassch@gmail.com>