### PR TITLE
Update doc with pci pf support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,6 @@ $ git checkout -b dev/some-topic-branch
 > We encourage contributor to test SRIOV Network Device plugin with various NICs to check the compatibility.
 >
 ## Contact Us
-- #General channel on [NPWG](https://npwg-team.slack.com/) Slack. Request an invite to NPWG slack [here](https://intel-corp.herokuapp.com/).
+- General channel on [NPWG](https://npwg-team.slack.com/) Slack. Request an invite to NPWG slack [here](https://intel-corp.herokuapp.com/).
 - Feel free to post GitHub issues and PRs for review
 - Attend either K8s Network & Resource mangement or Additional K8s Network & Resource management meetings

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 
 ## SR-IOV Network Device Plugin
 
-The SR-IOV Network Device Plugin is Kubernetes device plugin for discovering and advertising SR-IOV virtual functions (VFs) available on a Kubernetes host.
+The SR-IOV Network Device Plugin is Kubernetes device plugin for discovering and advertising networking resources in the
+form of SR-IOV virtual functions (VFs) and PCI physical functions (PFs) available on a Kubernetes host.
 
 ## Features
 
@@ -42,17 +43,19 @@ The SR-IOV Network Device Plugin is Kubernetes device plugin for discovering and
 - Extensible to support new device types with minimal effort if not already supported
 - Works within virtual deployments of Kubernetes that do not have virtualized-iommu support (VFIO No-IOMMU support)
 
-To deploy workloads with SR-IOV VF this plugin needs to work together with the following two CNI components:
+To deploy workloads with SR-IOV VF or PCI PF, this plugin needs to work together with the following two CNI components:
 
 - Any CNI meta plugin supporting Device Plugin based network provisioning (Multus CNI, or DANM)
 
   - Retrieves allocated network device information of a Pod
 
-- SR-IOV CNI
-
-  - During Pod creation, plumbs allocated SR-IOV VF to a Pods network namespace using VF information given by the meta plugin
-
-  - On Pod deletion, reset and release the VF from the Pod
+- A CNI capable of consuming the network device allocated to the Pod
+  - SR-IOV CNI (for SR-IOV VFs)
+    - During Pod creation, plumbs allocated SR-IOV VF to a Pods network namespace using VF information given by the meta plugin
+    - On Pod deletion, reset and release the VF from the Pod
+  - Host device CNI (for PCI PFs)
+    - During Pod creation, plumbs the allocated network device to the Pods network namespace using device information given by the meta plugin
+    - On Pod deletion, reset and release the allocated network device from the Pod
 
 
 Please follow the [Quick Start](#quick-start) for multi network interface support in Kubernetes.


### PR DESCRIPTION
SRIOV network device plugin supports discovery and allocation of non SR-IOV network devices.
Align documentation with this use-case.

In addition, fix typo in CONTRIBUTING doc (separate commit in this PR)