### PR TITLE
Update alpine image in Dockerfile

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:alpine3.12 as builder
+FROM golang:1.17-alpine as builder
 
 COPY . /usr/src/sriov-network-device-plugin
 ADD images/ddptool-1.0.1.12.tar.gz /tmp/ddptool/
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
-RUN apk add --no-cache --virtual build-dependencies build-base linux-headers
+RUN apk add --no-cache --virtual build-dependencies build-base linux-headers git
 
 WORKDIR /usr/src/sriov-network-device-plugin
 RUN make clean && \
@@ -14,7 +14,7 @@ RUN make clean && \
 WORKDIR /tmp/ddptool
 RUN make
 
-FROM alpine:3.12
+FROM alpine:3
 RUN apk add --no-cache hwdata-pci
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=builder /tmp/ddptool/ddptool /usr/bin/


### PR DESCRIPTION
alpine image has been pinned to 3.12 due to issues
that have already been resolved.

since sriov-network-device plugin image now properly builds
with latest alpine images, we can set it in Dockerfile.

As an additional benefit this will fix container image
related security vulnerabilities as new images are published.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>