### PR TITLE
Make advertising of NUMA node optional

### DIFF
--- a/pkg/accelerator/accelDevice.go
+++ b/pkg/accelerator/accelDevice.go
@@ -27,8 +27,9 @@ type accelDevice struct {
 }
 
 // NewAccelDevice returns an instance of AccelDevice interface
-func NewAccelDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory) (types.AccelDevice, error) {
-	pciDev, err := resources.NewPciDevice(dev, rFactory, nil)
+func NewAccelDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory,
+	rc *types.ResourceConfig) (types.AccelDevice, error) {
+	pciDev, err := resources.NewPciDevice(dev, rFactory, rc, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/accelerator/accelDeviceProvider.go
+++ b/pkg/accelerator/accelDeviceProvider.go
@@ -51,7 +51,7 @@ func (ap *accelDeviceProvider) GetDiscoveredDevices() []*ghw.PCIDevice {
 func (ap *accelDeviceProvider) GetDevices(rc *types.ResourceConfig) []types.PciDevice {
 	newPciDevices := make([]types.PciDevice, 0)
 	for _, device := range ap.deviceList {
-		if newDevice, err := NewAccelDevice(device, ap.rFactory); err == nil {
+		if newDevice, err := NewAccelDevice(device, ap.rFactory, rc); err == nil {
 			newPciDevices = append(newPciDevices, newDevice)
 		} else {
 			glog.Errorf("accelerator GetDevices() error creating new device: %q", err)

--- a/pkg/netdevice/pciNetDevice.go
+++ b/pkg/netdevice/pciNetDevice.go
@@ -73,7 +73,7 @@ func NewPciNetDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *typ
 		}
 	}
 
-	pciDev, err := resources.NewPciDevice(dev, rFactory, infoProviders)
+	pciDev, err := resources.NewPciDevice(dev, rFactory, rc, infoProviders)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/pciDevice.go
+++ b/pkg/resources/pciDevice.go
@@ -46,7 +46,8 @@ func nodeToStr(nodeNum int) string {
 // NewPciDevice returns an instance of PciDevice interface
 // A list of DeviceInfoProviders can be set externally.
 // If empty, the default driver-based selection provided by ResourceFactory will be used
-func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, infoProviders []types.DeviceInfoProvider) (types.PciDevice, error) {
+func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *types.ResourceConfig,
+	infoProviders []types.DeviceInfoProvider) (types.PciDevice, error) {
 	pciAddr := dev.Address
 
 	// Get PF PCI address
@@ -70,8 +71,11 @@ func NewPciDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory, infoProvid
 	if len(infoProviders) == 0 {
 		infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(pciAddr, driverName))
 	}
+	nodeNum := -1
+	if !rc.ExcludeTopology {
+		nodeNum = utils.GetDevNode(pciAddr)
+	}
 
-	nodeNum := utils.GetDevNode(pciAddr)
 	apiDevice := &pluginapi.Device{
 		ID:     pciAddr,
 		Health: pluginapi.Healthy,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -87,7 +87,7 @@ type ResourceConfig struct {
 	ResourcePrefix  string           `json:"resourcePrefix,omitempty"`
 	ResourceName    string           `json:"resourceName"` // the resource name will be added with resource prefix in K8s api
 	DeviceType      DeviceType       `json:"deviceType,omitempty"`
-	ExcludeTopology bool             `json:"exclude_topology,omitempty"`
+	ExcludeTopology bool             `json:"excludeTopology,omitempty"`
 	Selectors       *json.RawMessage `json:"selectors,omitempty"`
 	SelectorObj     interface{}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -84,11 +84,12 @@ var SupportedDevices = map[DeviceType]int{
 // ResourceConfig contains configuration parameters for a resource pool
 type ResourceConfig struct {
 	// optional resource prefix that will overwrite	global prefix specified in cli params
-	ResourcePrefix string           `json:"resourcePrefix,omitempty"`
-	ResourceName   string           `json:"resourceName"` // the resource name will be added with resource prefix in K8s api
-	DeviceType     DeviceType       `json:"deviceType,omitempty"`
-	Selectors      *json.RawMessage `json:"selectors,omitempty"`
-	SelectorObj    interface{}
+	ResourcePrefix  string           `json:"resourcePrefix,omitempty"`
+	ResourceName    string           `json:"resourceName"` // the resource name will be added with resource prefix in K8s api
+	DeviceType      DeviceType       `json:"deviceType,omitempty"`
+	ExcludeTopology bool             `json:"exclude_topology,omitempty"`
+	Selectors       *json.RawMessage `json:"selectors,omitempty"`
+	SelectorObj     interface{}
 }
 
 // DeviceSelectors contains common device selectors fields


### PR DESCRIPTION
This change adds support for making advertising of NUMA node optional.
This can be done per resource pool by setting the config
"exclude_topology" to true. Default behavior is to advertise NUMA node
information.

#320 

Signed-off-by: Ravindra Thakur <ravindra.nath.thakur@est.tech>