### PR TITLE
Bump plugin version to v3.4.0 in deployment examples

### DIFF
--- a/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.10-v1.15/sriovdp-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.3.2
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.4.0
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/deployments/k8s-v1.16/sriovdp-daemonset.yaml
+++ b/deployments/k8s-v1.16/sriovdp-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.3.2
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.4.0
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp


### PR DESCRIPTION
Proposal for the future:
Using a specific version of the plugin in deployment examples requires updating it for each release. This poses a risk of users
deploying an older version of the plugin than the specific one they checked out.

The proposal is to always use `latest` and then in every release, update yaml for the release and upload it to the release page.