### PR TITLE
Add Coveralls step in GH actions

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -23,6 +23,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOOS: ${{ matrix.goos }}
         run: make build
+
   test:
     runs-on: ubuntu-latest
     needs: build
@@ -42,16 +43,45 @@ jobs:
       - name: Go test
         run: make test
 
+  test-coverage:
+    runs-on: ubuntu-latest
+    needs: build
+    name: test-coverage
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16.x
+
+      - uses: actions/checkout@v2
+
+      - name: Install hwdata
+        run: sudo apt-get install hwdata -y
+
+      - name: Go test with coverage
+        run: make test-coverage
+      
+      - name: Coveralls
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: test/coverage/lcov.info
+
   golangci:
     name: Golangci-lint
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16.x
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.37
+
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.gopath/*
 /build/*
+/test/coverage*
 
 # Created by https://www.gitignore.io/api/go,macos,linux,windows,visualstudiocode
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,13 @@
 # Tested with golangci-lint ver. 1.37
 run:
   timeout: 3m
+  skip-dirs:
+    - vendor/
+    - .github/
+    - deployments/
+    - docs/
+    - images/
+
 linters-settings:
   depguard:
     list-type: blacklist
@@ -110,11 +117,3 @@ issues:
         - lll
         - stylecheck
         - goconst
-
-run:
-  skip-dirs:
-    - vendor/
-    - .github/
-    - deployments/
-    - docs/
-    - images/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # SR-IOV Network Device Plugin for Kubernetes
 
 [![Travis CI](https://travis-ci.org/k8snetworkplumbingwg/sriov-network-device-plugin.svg?branch=master)](https://travis-ci.org/k8snetworkplumbingwg/sriov-network-device-plugin/builds) [![Go Report Card](https://goreportcard.com/badge/github.com/k8snetworkplumbingwg/sriov-network-device-plugin)](https://goreportcard.com/report/github.com/k8snetworkplumbingwg/sriov-network-device-plugin) [![Weekly minutes](https://img.shields.io/badge/Weekly%20Meeting%20Minutes-Mon%203pm%20GMT-blue.svg?style=plastic)](https://docs.google.com/document/d/1sJQMHbxZdeYJPgAWK1aSt6yzZ4K_8es7woVIrwinVwI)
+[![Coverage Status](https://coveralls.io/repos/github/k8snetworkplumbingwg/sriov-network-device-plugin/badge.svg?branch=master)](https://coveralls.io/github/k8snetworkplumbingwg/sriov-network-device-plugin?branch=master)
 
 ## Table of Contents
 


### PR DESCRIPTION
> Make code coverage profile output deterministic, in
> order to be collected by coveralls.io step.
> 
> Add coveralls badge to README.md
> 
> Signed-off-by: Andrea Panattoni <apanatto@redhat.com>

Coverage on this repository is [~77%](https://coveralls.io/github/zeeke/sriov-network-device-plugin). That's a very good percentage and this PR makes it recorded in future PRs.

If it is appreciated, I can add a coverage threshold to GH actions as described in [this blog post](https://medium.com/synechron/how-to-set-up-a-test-coverage-threshold-in-go-and-github-167f69b940dc).