### PR TITLE
Update docs for excludeTopology config

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ This plugin creates device plugin endpoints based on the configurations given in
 | "resourceName"   | Y        | Endpoint resource name. Should not contain special characters including hyphens and must be unique in the scope of the resource prefix | string                                                | "sriov_net_A"                                                   |
 | "resourcePrefix" | N        | Endpoint resource prefix name override. Should not contain special characters                                     | string Default : "intel.com"                          | "yourcompany.com"                                               |
 | "deviceType"     | N        | Device Type for a resource pool.                                                                                  | string value of supported types. Default: "netDevice" | Currently supported values: "accelerator", "netDevice"          |
+| "excludeTopology" | N       | Exclude advertising of device's NUMA topology          | bool Default: "false"    | "excludeTopology": true          |
 | "selectors"      | N        | A map of device selectors. The "deviceType" value determines the "selectors" options.                             | json object as string Default: null                   | Example: "selectors": {"vendors": ["8086"],"devices": ["154c"]} |
 
 


### PR DESCRIPTION
Updated README to include documentation for "excludeTopology" config.
This config allows making advertising of device's NUMA toplogy optional.

#320 

Signed-off-by: Ravindra Thakur <ravindra.nath.thakur@est.tech>