### PR TITLE
Sf support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Mellanox/rdmamap v1.0.0
-	github.com/Mellanox/sriovnet v1.0.3
+	github.com/Mellanox/sriovnet v1.1.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/jaypipes/ghw v0.6.0
 	github.com/jaypipes/pcidb v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/Mellanox/rdmamap v1.0.0 h1:5OQX6n85GDKetHP9wBqxy/0Ce2+taRg+4nSTsNOCyK
 github.com/Mellanox/rdmamap v1.0.0/go.mod h1:fN+/V9lf10ABnDCwTaXRjeeWijLt2iVLETnK+sx/LY8=
 github.com/Mellanox/sriovnet v1.0.3 h1:Nlmxr2mkp16aIP4CJcsnqCczxQQgOuzNDm/nu9qTBZ8=
 github.com/Mellanox/sriovnet v1.0.3/go.mod h1:8TlYc3iOTEvUM+WAbC7MU6U6JXqIfhl2DcWIGVUsjIE=
+github.com/Mellanox/sriovnet v1.1.0 h1:j3KnktNJMHWPTqWXlf27OzQG0ahRO+88NauMjlazyko=
+github.com/Mellanox/sriovnet v1.1.0/go.mod h1:P2Epf+52ZaPknkR60EUOvLABXZh3FBymcHPsUfikRVE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -90,6 +90,8 @@ func (rf *resourceFactory) GetSelector(attr string, values []string) (types.Devi
 		return resources.NewLinkTypeSelector(values), nil
 	case "ddpProfiles":
 		return resources.NewDdpSelector(values), nil
+	case "auxDevices":
+		return resources.NewAuxDeviceSelector(values), nil
 	default:
 		return nil, fmt.Errorf("GetSelector(): invalid attribute %s", attr)
 	}

--- a/pkg/netdevice/auxNetDevice.go
+++ b/pkg/netdevice/auxNetDevice.go
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package netdevice
+
+import (
+	"github.com/golang/glog"
+	"github.com/jaypipes/ghw"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/resources"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
+)
+
+func newAuxNetDevice(dev *ghw.PCIDevice, auxDev string, rFactory types.ResourceFactory, rc *types.ResourceConfig) (types.PciNetDevice, error) {
+	infoProviders := make([]types.DeviceInfoProvider, 0)
+
+	driverName, err := utils.GetDriverName(dev.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	infoProviders = append(infoProviders, rFactory.GetDefaultInfoProvider(auxDev, driverName))
+
+	var rdmaSpec types.RdmaSpec
+	nf, ok := rc.SelectorObj.(*types.NetDeviceSelectors)
+	if ok {
+		// Add InfoProviders based on Selector data
+		if nf.IsRdma {
+			rdmaSpec = NewAuxRdmaSpec(auxDev)
+			if rdmaSpec.IsRdma() {
+				infoProviders = append(infoProviders, NewRdmaInfoProvider(rdmaSpec))
+			} else {
+				glog.Warningf("RDMA resources for %s not found. Are RDMA modules loaded?", auxDev)
+			}
+		}
+	}
+
+	pciDev, err := resources.NewPciDevice(dev, rFactory, rc, infoProviders)
+	if err != nil {
+		return nil, err
+	}
+
+	// that's a hack to be able to use auxiliary ID as device ID
+	apiDevice := pciDev.GetAPIDevice()
+	apiDevice.ID = auxDev
+
+	pfName, err := utils.GetUplinkRepresentorFromAuxDev(auxDev)
+	if err != nil {
+		glog.Warningf("unable to get PF name %q for device %s", err.Error(), auxDev)
+	}
+
+	linkType := ""
+	ifName, _ := utils.GetAuxDevIfName(auxDev)
+	if len(ifName) > 0 {
+		la, err := utils.GetNetlinkProvider().GetLinkAttrs(ifName)
+		if err != nil {
+			return nil, err
+		}
+		linkType = la.EncapType
+	}
+
+	return &pciNetDevice{
+		PciDevice: pciDev,
+		ifName:    ifName,
+		pfName:    pfName,
+		linkSpeed: "", // TODO: Get this using utils pkg
+		rdmaSpec:  rdmaSpec,
+		linkType:  linkType,
+	}, nil
+}
+
+// NewAuxNetDevices creates auxiliary devices for specified PCI device
+func NewAuxNetDevices(dev *ghw.PCIDevice, rFactory types.ResourceFactory, rc *types.ResourceConfig) ([]types.PciDevice, error) {
+	newPciDevices := make([]types.PciDevice, 0)
+	auxDevs, err := utils.GetAuxNetDevicesFromPci(dev.Address)
+	if err != nil {
+		return nil, err
+	}
+	for _, auxDev := range auxDevs {
+		if newDevice, err := newAuxNetDevice(dev, auxDev, rFactory, rc); err == nil {
+			newPciDevices = append(newPciDevices, newDevice)
+		} else {
+			glog.Errorf("netdevice NewAuxNetDevices(): error creating new auxiliary device: %q", err)
+		}
+	}
+	return newPciDevices, nil
+}

--- a/pkg/netdevice/auxNetDevice_test.go
+++ b/pkg/netdevice/auxNetDevice_test.go
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package netdevice_test
+
+import (
+	"github.com/jaypipes/ghw"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/factory"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/netdevice"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils/mocks"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AuxNetDevice", func() {
+	Describe("creation", func() {
+		Context("correct input", func() {
+			It("should create 2 devices", func() {
+				rc := &types.ResourceConfig{}
+				fs := &utils.FakeFilesystem{
+					Dirs: []string{
+						"sys/bus/pci/devices/0000:00:00.1/foo.bar.0",
+						"sys/bus/pci/devices/0000:00:00.1/foo.bar.1",
+						"sys/bus/pci/drivers/foo",
+					},
+					Symlinks: map[string]string{
+						"sys/bus/pci/devices/0000:00:00.1/driver": "../../../../bus/pci/drivers/foo",
+					},
+				}
+				defer fs.Use()()
+				f := factory.NewResourceFactory("fake", "fake", true)
+				dev := &ghw.PCIDevice{Address: "0000:00:00.1"}
+
+				auxDevs, err := netdevice.NewAuxNetDevices(dev, f, rc)
+				Expect(auxDevs).ToNot(BeNil())
+				Expect(auxDevs).To(HaveLen(len(fs.Dirs) - 1))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should create device with correct field values", func() {
+				rc := &types.ResourceConfig{}
+				fs := &utils.FakeFilesystem{
+					Dirs: []string{
+						"sys/bus/auxiliary/devices",
+						"sys/bus/pci/devices/0000:00:00.1/foo.bar.0/net/eth0",
+						"sys/bus/pci/devices/0000:00:00.1/net/net0",
+						"sys/bus/pci/drivers/foo",
+					},
+					Symlinks: map[string]string{
+						"sys/bus/auxiliary/devices/foo.bar.0":     "../../../bus/pci/devices/0000:00:00.1/foo.bar.0",
+						"sys/bus/pci/devices/0000:00:00.1/driver": "../../../../bus/pci/drivers/foo",
+					},
+				}
+				defer fs.Use()()
+				f := factory.NewResourceFactory("fake", "fake", true)
+				dev := &ghw.PCIDevice{Address: "0000:00:00.1"}
+
+				fakeSriovnetProvider := mocks.SriovnetProvider{}
+				fakeSriovnetProvider.
+					On("GetUplinkRepresentorFromAux", mock.AnythingOfType("string")).Return("net0", nil)
+				utils.SetSriovnetProviderInst(&fakeSriovnetProvider)
+
+				auxDevs, err := netdevice.NewAuxNetDevices(dev, f, rc)
+				Expect(auxDevs).ToNot(BeNil())
+				Expect(auxDevs).To(HaveLen(1))
+				Expect(err).ToNot(HaveOccurred())
+				auxDev, _ := auxDevs[0].(types.PciNetDevice)
+				Expect(auxDev.GetDriver()).To(Equal("foo"))
+				Expect(auxDev.GetNetName()).To(Equal("eth0"))
+				Expect(auxDev.GetEnvVal()).To(Equal("foo.bar.0"))
+				Expect(auxDev.GetDeviceSpecs()).To(HaveLen(0))
+				Expect(auxDev.GetLinkSpeed()).To(Equal(""))
+				Expect(auxDev.GetPFName()).To(Equal("net0"))
+				Expect(auxDev.GetRdmaSpec()).To(BeNil())
+				Expect(auxDev.GetLinkType()).To(Equal("fakeLinkType"))
+				Expect(auxDev.GetAPIDevice().ID).To(Equal("foo.bar.0"))
+			})
+		})
+		Context("incorrect input", func() {
+			It("invalid pci device", func() {
+				rc := &types.ResourceConfig{}
+				f := factory.NewResourceFactory("fake", "fake", true)
+				dev := &ghw.PCIDevice{Address: "0000:00:00.1"}
+
+				auxDevs, err := netdevice.NewAuxNetDevices(dev, f, rc)
+				Expect(auxDevs).To(BeNil())
+				Expect(err).To(HaveOccurred())
+			})
+			It("no ifName", func() {
+				rc := &types.ResourceConfig{}
+				fs := &utils.FakeFilesystem{
+					Dirs: []string{
+						"sys/bus/pci/devices/0000:00:00.1/foo.bar.0",
+						"sys/bus/pci/drivers/foo",
+					},
+					Symlinks: map[string]string{"sys/bus/pci/devices/0000:00:00.1/driver": "../../../../bus/pci/drivers/foo"},
+				}
+				defer fs.Use()()
+				utils.SetDefaultMockNetlinkProvider()
+				f := factory.NewResourceFactory("fake", "fake", true)
+				dev := &ghw.PCIDevice{Address: "0000:00:00.1"}
+
+				auxDevs, err := netdevice.NewAuxNetDevices(dev, f, rc)
+				Expect(auxDevs).ToNot(BeNil())
+				Expect(auxDevs).To(HaveLen(1))
+				Expect(err).ToNot(HaveOccurred())
+				auxDev, _ := auxDevs[0].(types.PciNetDevice)
+				Expect(auxDev.GetNetName()).To(Equal(""))
+				Expect(auxDev.GetLinkType()).To(Equal(""))
+			})
+			It("no auxiliary devices", func() {
+				rc := &types.ResourceConfig{}
+				fs := &utils.FakeFilesystem{Dirs: []string{"sys/bus/pci/devices/0000:00:00.1"}}
+				defer fs.Use()()
+				f := factory.NewResourceFactory("fake", "fake", true)
+				dev := &ghw.PCIDevice{Address: "0000:00:00.1"}
+
+				auxDevs, err := netdevice.NewAuxNetDevices(dev, f, rc)
+				Expect(auxDevs).ToNot(BeNil())
+				Expect(auxDevs).To(HaveLen(0))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("no driver name", func() {
+				rc := &types.ResourceConfig{}
+				fs := &utils.FakeFilesystem{Dirs: []string{"sys/bus/pci/devices/0000:00:00.1/foo.bar.0"}}
+				defer fs.Use()()
+				f := factory.NewResourceFactory("fake", "fake", true)
+				dev := &ghw.PCIDevice{Address: "0000:00:00.1"}
+
+				auxDevs, err := netdevice.NewAuxNetDevices(dev, f, rc)
+				Expect(auxDevs).ToNot(BeNil())
+				Expect(auxDevs).To(HaveLen(0))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/netdevice/netDeviceProvider_test.go
+++ b/pkg/netdevice/netDeviceProvider_test.go
@@ -76,7 +76,7 @@ var _ = Describe("NetDeviceProvider", func() {
 			p := netdevice.NewNetDeviceProvider(rf)
 			config := &types.ResourceConfig{
 				DeviceType: types.NetDeviceType,
-				SelectorObj: types.NetDeviceSelectors{
+				SelectorObj: &types.NetDeviceSelectors{
 					DeviceSelectors: types.DeviceSelectors{},
 				},
 			}

--- a/pkg/netdevice/rdma.go
+++ b/pkg/netdevice/rdma.go
@@ -1,10 +1,14 @@
 package netdevice
 
 import (
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/Mellanox/rdmamap"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 )
 
 type rdmaSpec struct {
@@ -12,11 +16,9 @@ type rdmaSpec struct {
 	deviceSpec    []*pluginapi.DeviceSpec
 }
 
-// NewRdmaSpec returns the RdmaSpec
-func NewRdmaSpec(pciAddrs string) types.RdmaSpec {
+func newRdmaSpec(rdmaResources []string) types.RdmaSpec {
 	deviceSpec := make([]*pluginapi.DeviceSpec, 0)
 	isSupportRdma := false
-	rdmaResources := rdmamap.GetRdmaDevicesForPcidev(pciAddrs)
 	if len(rdmaResources) > 0 {
 		isSupportRdma = true
 		for _, res := range rdmaResources {
@@ -32,6 +34,37 @@ func NewRdmaSpec(pciAddrs string) types.RdmaSpec {
 	}
 
 	return &rdmaSpec{isSupportRdma: isSupportRdma, deviceSpec: deviceSpec}
+}
+
+// NewRdmaSpec returns the RdmaSpec for pci device
+func NewRdmaSpec(pciAddrs string) types.RdmaSpec {
+	rdmaResources := rdmamap.GetRdmaDevicesForPcidev(pciAddrs)
+	return newRdmaSpec(rdmaResources)
+}
+
+func getRdmaDevicesForAuxdev(auxDev string) []string {
+	var rdmaResources []string
+
+	dirName := filepath.Join(utils.SysBusAux, auxDev, rdmamap.RdmaClassName)
+
+	entries, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		return rdmaResources
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() == false {
+			continue
+		}
+		rdmaResources = append(rdmaResources, entry.Name())
+	}
+	return rdmaResources
+}
+
+// NewAuxRdmaSpec returns the RdmaSpec for auxiliary device
+func NewAuxRdmaSpec(auxID string) types.RdmaSpec {
+	rdmaResources := getRdmaDevicesForAuxdev(auxID)
+	return newRdmaSpec(rdmaResources)
 }
 
 func (r *rdmaSpec) IsRdma() bool {

--- a/pkg/resources/deviceSelectors.go
+++ b/pkg/resources/deviceSelectors.go
@@ -167,6 +167,33 @@ func (s *linkTypeSelector) Filter(inDevices []types.PciDevice) []types.PciDevice
 	return filteredList
 }
 
+// NewAuxDeviceSelector returns a NetDevSelector interface for netDev list
+func NewAuxDeviceSelector(devices []string) types.DeviceSelector {
+	return &auxDeviceSelector{auxDevices: devices}
+}
+
+type auxDeviceSelector struct {
+	auxDevices []string
+}
+
+func (s *auxDeviceSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
+	filteredList := make([]types.PciDevice, 0)
+	for _, dev := range inDevices {
+		// auxiliary devices have <driver_name>.<device>.<id> instead of pciAddress
+		chunks := strings.Split(dev.GetAPIDevice().ID, ".")
+		if len(chunks) != 3 {
+			// XXX expected that inDevices is auxiliary devices list but
+			// we got pci devices. Just skip for now.
+			continue
+		}
+		if contains(s.auxDevices, chunks[1]) {
+			filteredList = append(filteredList, dev)
+		}
+	}
+
+	return filteredList
+}
+
 func contains(hay []string, needle string) bool {
 	for _, s := range hay {
 		if s == needle {

--- a/pkg/resources/deviceSelectors_test.go
+++ b/pkg/resources/deviceSelectors_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types/mocks"
 
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -268,6 +270,40 @@ var _ = Describe("DeviceSelectors", func() {
 
 				Expect(filtered).To(ContainElement(&dev0))
 				Expect(filtered).NotTo(ContainElement(&dev1))
+			})
+		})
+	})
+
+	Describe("auxDevices selector", func() {
+		Context("filtering", func() {
+			It("should return devices matching the correct auxiliary device", func() {
+				auxDevices := []string{"bar"}
+				sel := resources.NewAuxDeviceSelector(auxDevices)
+
+				dev0 := mocks.PciDevice{}
+				dev0.On("GetAPIDevice").Return(&pluginapi.Device{ID: "foo.bar.0"})
+				dev1 := mocks.PciDevice{}
+				dev1.On("GetAPIDevice").Return(&pluginapi.Device{ID: "foo.baz.0"})
+
+				in := []types.PciDevice{&dev0, &dev1}
+				filtered := sel.Filter(in)
+
+				Expect(filtered).To(ContainElement(&dev0))
+				Expect(filtered).NotTo(ContainElement(&dev1))
+			})
+			It("should return all the matched devices", func() {
+				auxDevices := []string{"bar", "baz"}
+				sel := resources.NewAuxDeviceSelector(auxDevices)
+
+				dev0 := mocks.PciDevice{}
+				dev0.On("GetAPIDevice").Return(&pluginapi.Device{ID: "foo.bar.0"})
+				dev1 := mocks.PciDevice{}
+				dev1.On("GetAPIDevice").Return(&pluginapi.Device{ID: "foo.baz.0"})
+
+				in := []types.PciDevice{&dev0, &dev1}
+				filtered := sel.Filter(in)
+
+				Expect(filtered).To(Equal(in))
 			})
 		})
 	})

--- a/pkg/resources/pciDevice.go
+++ b/pkg/resources/pciDevice.go
@@ -114,7 +114,7 @@ func (pd *pciDevice) GetDeviceCode() string {
 }
 
 func (pd *pciDevice) GetPciAddr() string {
-	return pd.basePciDevice.Address
+	return pd.apiDevice.ID
 }
 
 func (pd *pciDevice) GetDriver() string {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -110,6 +110,7 @@ type NetDeviceSelectors struct {
 	IsRdma       bool     // the resource support rdma
 	NeedVhostNet bool     // share vhost-net along the selected resource
 	VdpaType     VdpaType `json:"vdpaType,omitempty"`
+	AuxDevices   []string `json:"auxDevices,omitempty"`
 }
 
 // AccelDeviceSelectors contains accelerator(FPGA etc.) related selectors fields

--- a/pkg/utils/mocks/SriovnetProvider.go
+++ b/pkg/utils/mocks/SriovnetProvider.go
@@ -30,6 +30,27 @@ func (_m *SriovnetProvider) GetUplinkRepresentor(vfPciAddress string) (string, e
 	return r0, r1
 }
 
+// GetUplinkRepresentorFromAux provides a mock function with given fields: auxDev
+func (_m *SriovnetProvider) GetUplinkRepresentorFromAux(auxDev string) (string, error) {
+	ret := _m.Called(auxDev)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(auxDev)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(auxDev)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type NewSriovnetProviderT interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/utils/sriovnet_provider.go
+++ b/pkg/utils/sriovnet_provider.go
@@ -7,6 +7,7 @@ import (
 // SriovnetProvider is a wrapper type over sriovnet library
 type SriovnetProvider interface {
 	GetUplinkRepresentor(vfPciAddress string) (string, error)
+	GetUplinkRepresentorFromAux(auxDev string) (string, error)
 }
 
 type defaultSriovnetProvider struct {
@@ -26,4 +27,8 @@ func GetSriovnetProvider() SriovnetProvider {
 
 func (defaultSriovnetProvider) GetUplinkRepresentor(vfPciAddress string) (string, error) {
 	return sriovnet.GetUplinkRepresentor(vfPciAddress)
+}
+
+func (defaultSriovnetProvider) GetUplinkRepresentorFromAux(auxDev string) (string, error) {
+	return sriovnet.GetUplinkRepresentorFromAux(auxDev)
 }

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -70,6 +70,7 @@ func (fs *FakeFilesystem) Use() func() {
 	}
 
 	sysBusPci = path.Join(fs.RootDir, "/sys/bus/pci/devices")
+	SysBusAux = path.Join(fs.RootDir, "/sys/bus/auxiliary/devices")
 
 	return func() {
 		// remove temporary fake fs

--- a/vendor/github.com/Mellanox/sriovnet/sriovnet_aux.go
+++ b/vendor/github.com/Mellanox/sriovnet/sriovnet_aux.go
@@ -1,0 +1,89 @@
+/*----------------------------------------------------
+ *
+ *  2022 NVIDIA CORPORATION & AFFILIATES
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License);
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an AS IS BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *----------------------------------------------------
+ */
+
+package sriovnet
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	utilfs "github.com/Mellanox/sriovnet/pkg/utils/filesystem"
+)
+
+// GetNetDeviceFromAux gets auxiliary device name (e.g 'mlx5_core.sf.2') and
+// returns the correlate netdevice
+func GetNetDevicesFromAux(auxDev string) ([]string, error) {
+	auxDir := filepath.Join(AuxSysDir, auxDev, "net")
+	return getFileNamesFromPath(auxDir)
+}
+
+// GetSfIndexByAuxDev gets a SF device name (e.g 'mlx5_core.sf.2') and
+// returns the correlate SF index.
+func GetSfIndexByAuxDev(auxDev string) (int, error) {
+	sfNumFile := filepath.Join(AuxSysDir, auxDev, "sfnum")
+	if _, err := utilfs.Fs.Stat(sfNumFile); err != nil {
+		return -1, fmt.Errorf("cannot get sfnum for %s device: %v", auxDev, err)
+	}
+
+	sfNumStr, err := utilfs.Fs.ReadFile(sfNumFile)
+	if err != nil {
+		return -1, fmt.Errorf("cannot read sfnum file for %s device: %v", auxDev, err)
+	}
+
+	sfnum, err := strconv.Atoi(strings.TrimSpace(string(sfNumStr)))
+	if err != nil {
+		return -1, err
+	}
+	return sfnum, nil
+}
+
+// GetPfPciFromAux retrieves the parent PF PCI address of the provided auxiliary device in D.T.f format
+func GetPfPciFromAux(auxDev string) (string, error) {
+	auxPath := filepath.Join(AuxSysDir, auxDev)
+	absoluteAuxPath, err := utilfs.Fs.Readlink(auxPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read auxiliary link, provided device ID may be not auxiliary device. %v", err)
+	}
+	// /sys/bus/auxiliary/devices/mlx5_core.sf.7 ->
+	//		./../../devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0/mlx5_core.sf.7
+	parent := filepath.Dir(absoluteAuxPath)
+	base := filepath.Base(parent)
+	for !pciAddressRe.MatchString(base) {
+		// it's a nested auxiliary device. repeat
+		parent = filepath.Dir(parent)
+		base = filepath.Base(parent)
+	}
+	if base == "" {
+		return base, fmt.Errorf("could not find PF PCI Address")
+	}
+	return base, err
+}
+
+// GetUplinkRepresentorFromAux gets auxiliary device name (e.g 'mlx5_core.sf.2') and
+// returns the uplink representor netdev name for device.
+func GetUplinkRepresentorFromAux(auxDev string) (string, error) {
+	pfPci, err := GetPfPciFromAux(auxDev)
+	if err != nil {
+		return "", fmt.Errorf("failed to find uplink PCI device: %v", err)
+	}
+
+	return GetUplinkRepresentor(pfPci)
+}

--- a/vendor/github.com/Mellanox/sriovnet/sriovnet_helper.go
+++ b/vendor/github.com/Mellanox/sriovnet/sriovnet_helper.go
@@ -10,6 +10,7 @@ import (
 const (
 	NetSysDir        = "/sys/class/net"
 	PciSysDir        = "/sys/bus/pci/devices"
+	AuxSysDir        = "/sys/bus/auxiliary/devices"
 	pcidevPrefix     = "device"
 	netdevDriverDir  = "device/driver"
 	netdevUnbindFile = "unbind"

--- a/vendor/github.com/Mellanox/sriovnet/utils.go
+++ b/vendor/github.com/Mellanox/sriovnet/utils.go
@@ -1,0 +1,45 @@
+/*----------------------------------------------------
+ *
+ *  2022 NVIDIA CORPORATION & AFFILIATES
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License);
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an AS IS BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *----------------------------------------------------
+ */
+
+package sriovnet
+
+import (
+	"fmt"
+	"strings"
+
+	utilfs "github.com/Mellanox/sriovnet/pkg/utils/filesystem"
+)
+
+func getFileNamesFromPath(dir string) ([]string, error) {
+	_, err := utilfs.Fs.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("could not stat the directory %s: %v", dir, err)
+	}
+
+	files, err := utilfs.Fs.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %v", dir, err)
+	}
+
+	netDevices := make([]string, 0, len(files))
+	for _, netDeviceFile := range files {
+		netDevices = append(netDevices, strings.TrimSpace(netDeviceFile.Name()))
+	}
+	return netDevices, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/Mellanox/rdmamap v1.0.0
 ## explicit; go 1.13
 github.com/Mellanox/rdmamap
-# github.com/Mellanox/sriovnet v1.0.3
+# github.com/Mellanox/sriovnet v1.1.0
 ## explicit; go 1.13
 github.com/Mellanox/sriovnet
 github.com/Mellanox/sriovnet/pkg/utils/filesystem


### PR DESCRIPTION
This series adds mechanism to discover SFs or any other auxiliary devices on parent PCI device if they requested in configuration. For example, this config defines SF resources:

```
{
    "resourceList": [{
        "resourceName": "bf2_sf",
        "resourcePrefix": "nvidia.com",
        "selectors": {
            "pfNames": ["p0"],
            "auxDevices": ["sf"]
        }
    }]
}
```

When `auxTypes` field is provided, for each discovered PCI device all related auxiliary devices will be discovered making resource pool from this devices instead of original PCI devices. If `auxTypes` field were omitted (not just empty), then resource pool created as usual. Values for `auxTypes` are not hard coded but driver specific.
Because auxiliary device doesn't have its own dedicated PCI device, but plugin expects that all devices are PCI devices, auxiliary devices extends PCI device data type, where all PCI related fields are taken from parent PCI device. In this way plugin can apply selectors and allocate device on request. However id selectors doesn't work currently. This issue will be fixed by additional merge request.

Fixes: #430 