### PR TITLE
Implement and use probe function

### DIFF
--- a/pkg/accelerator/accelResourcePool.go
+++ b/pkg/accelerator/accelResourcePool.go
@@ -31,9 +31,8 @@ type accelResourcePool struct {
 var _ types.ResourcePool = &accelResourcePool{}
 
 // NewAccelResourcePool returns an instance of resourcePool
-func NewAccelResourcePool(rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device,
-	devicePool map[string]types.PciDevice) types.ResourcePool {
-	rp := resources.NewResourcePool(rc, apiDevices, devicePool)
+func NewAccelResourcePool(rc *types.ResourceConfig, deviceProvider types.DeviceProvider, allocated *map[string]bool) types.ResourcePool {
+	rp := resources.NewResourcePool(rc, deviceProvider, allocated)
 	s, _ := rc.SelectorObj.(*types.AccelDeviceSelectors)
 	return &accelResourcePool{
 		ResourcePoolImpl: rp,

--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -35,9 +35,8 @@ type netResourcePool struct {
 var _ types.ResourcePool = &netResourcePool{}
 
 // NewNetResourcePool returns an instance of resourcePool
-func NewNetResourcePool(nadutils types.NadUtils, rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device,
-	devicePool map[string]types.PciDevice) types.ResourcePool {
-	rp := resources.NewResourcePool(rc, apiDevices, devicePool)
+func NewNetResourcePool(nadutils types.NadUtils, rc *types.ResourceConfig, deviceProvider types.DeviceProvider, allocated *map[string]bool) types.ResourcePool {
+	rp := resources.NewResourcePool(rc, deviceProvider, allocated)
 	s, _ := rc.SelectorObj.(*types.NetDeviceSelectors)
 	return &netResourcePool{
 		ResourcePoolImpl: rp,
@@ -51,11 +50,11 @@ func (rp *netResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Devic
 	glog.Infof("GetDeviceSpecs(): for devices: %v", deviceIDs)
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
 
-	devicePool := rp.GetDevicePool()
+	deviceWithID := rp.GetDevicePool()
 
 	// Add device driver specific and rdma specific devices
 	for _, id := range deviceIDs {
-		if dev, ok := devicePool[id]; ok {
+		if dev, ok := deviceWithID[id]; ok {
 			netDev := dev.(types.PciNetDevice) // convert generic PciDevice to PciNetDevice
 			newSpecs := netDev.GetDeviceSpecs()
 			for _, ds := range newSpecs {

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -131,21 +131,7 @@ func (rs *resourceServer) Allocate(ctx context.Context, rqt *pluginapi.AllocateR
 
 func (rs *resourceServer) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.DevicePlugin_ListAndWatchServer) error {
 	methodID := fmt.Sprintf("ListAndWatch(%s)", rs.resourcePool.GetResourceName()) // for logging purpose
-	glog.Infof("%s invoked", methodID)
-	// Send initial list of devices
-	devs := make([]*pluginapi.Device, 0)
 	resp := new(pluginapi.ListAndWatchResponse)
-	for _, dev := range rs.resourcePool.GetDevices() {
-		devs = append(devs, dev)
-	}
-	resp.Devices = devs
-	glog.Infof("%s: send devices %v\n", methodID, resp)
-
-	if err := stream.Send(resp); err != nil {
-		glog.Errorf("%s: error: cannot update device states: %v\n", methodID, err)
-		rs.grpcServer.Stop()
-		return err
-	}
 
 	// listen for events: if updateSignal send new list of devices
 	for {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,7 +17,6 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/jaypipes/ghw"
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
@@ -139,7 +138,7 @@ type ResourceFactory interface {
 	GetResourceServer(ResourcePool) (ResourceServer, error)
 	GetDefaultInfoProvider(string, string) DeviceInfoProvider
 	GetSelector(string, []string) (DeviceSelector, error)
-	GetResourcePool(rc *ResourceConfig, deviceList []PciDevice) (ResourcePool, error)
+	GetResourcePool(rc *ResourceConfig, deviceProvider DeviceProvider, allocated *map[string]bool) (ResourcePool, error)
 	GetRdmaSpec(string) RdmaSpec
 	GetVdpaDevice(string) VdpaDevice
 	GetDeviceProvider(DeviceType) DeviceProvider
@@ -163,9 +162,8 @@ type ResourcePool interface {
 
 // DeviceProvider provides interface for device discovery
 type DeviceProvider interface {
-	// AddTargetDevices adds a list of devices in a DeviceProvider that matches the 'device class hexcode as int'
-	AddTargetDevices([]*ghw.PCIDevice, int) error
-	GetDiscoveredDevices() []*ghw.PCIDevice
+	// DiscoverDevices updates the list of devices in a DeviceProvider that matches the right 'device class hexcode as int'
+	DiscoverDevices()
 
 	// GetDevices runs through the Discovered Devices and returns a list of fully populated PciDevices according to the given ResourceConfig
 	GetDevices(*ResourceConfig) []PciDevice


### PR DESCRIPTION
Instead of having to rely on restarts to detect changes to the devices,
use the probe function (which is called periodically) to scan for
(changes to) devices. If a change is detected, the new list of devices
is advertised to kubelet.