### PR TITLE
Remove IsSriovPF as unused method of PciDevice interface

### DIFF
--- a/pkg/resources/pciDevice.go
+++ b/pkg/resources/pciDevice.go
@@ -108,10 +108,6 @@ func (pd *pciDevice) GetDriver() string {
 	return pd.driver
 }
 
-func (pd *pciDevice) IsSriovPF() bool {
-	return false
-}
-
 func (pd *pciDevice) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	dSpecs := make([]*pluginapi.DeviceSpec, 0)
 	for _, infoProvider := range pd.infoProviders {

--- a/pkg/types/mocks/AccelDevice.go
+++ b/pkg/types/mocks/AccelDevice.go
@@ -159,20 +159,6 @@ func (_m *AccelDevice) GetVendor() string {
 	return r0
 }
 
-// IsSriovPF provides a mock function with given fields:
-func (_m *AccelDevice) IsSriovPF() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 type NewAccelDeviceT interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/types/mocks/PciDevice.go
+++ b/pkg/types/mocks/PciDevice.go
@@ -159,20 +159,6 @@ func (_m *PciDevice) GetVendor() string {
 	return r0
 }
 
-// IsSriovPF provides a mock function with given fields:
-func (_m *PciDevice) IsSriovPF() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 type NewPciDeviceT interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/types/mocks/PciNetDevice.go
+++ b/pkg/types/mocks/PciNetDevice.go
@@ -261,20 +261,6 @@ func (_m *PciNetDevice) GetVendor() string {
 	return r0
 }
 
-// IsSriovPF provides a mock function with given fields:
-func (_m *PciNetDevice) IsSriovPF() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 type NewPciNetDeviceT interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -184,7 +184,6 @@ type PciDevice interface {
 	GetDeviceCode() string
 	GetPciAddr() string
 	GetPfPciAddr() string
-	IsSriovPF() bool
 	GetDeviceSpecs() []*pluginapi.DeviceSpec
 	GetEnvVal() string
 	GetMounts() []*pluginapi.Mount


### PR DESCRIPTION
This check is done by utility function with the same name, hence
remove method as unused.

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>