### PR TITLE
Remove API devices from reosurcePool

### DIFF
--- a/pkg/accelerator/accelResourcePool.go
+++ b/pkg/accelerator/accelResourcePool.go
@@ -31,9 +31,8 @@ type accelResourcePool struct {
 var _ types.ResourcePool = &accelResourcePool{}
 
 // NewAccelResourcePool returns an instance of resourcePool
-func NewAccelResourcePool(rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device,
-	devicePool map[string]types.PciDevice) types.ResourcePool {
-	rp := resources.NewResourcePool(rc, apiDevices, devicePool)
+func NewAccelResourcePool(rc *types.ResourceConfig, devicePool map[string]types.PciDevice) types.ResourcePool {
+	rp := resources.NewResourcePool(rc, devicePool)
 	s, _ := rc.SelectorObj.(*types.AccelDeviceSelectors)
 	return &accelResourcePool{
 		ResourcePoolImpl: rp,

--- a/pkg/accelerator/accelResourcePool_test.go
+++ b/pkg/accelerator/accelResourcePool_test.go
@@ -17,7 +17,6 @@ package accelerator_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/accelerator"
@@ -28,10 +27,9 @@ import (
 var _ = Describe("AccelResourcePool", func() {
 	Context("getting a new instance of the pool", func() {
 		rc := &types.ResourceConfig{ResourceName: "fake", ResourcePrefix: "fake"}
-		devs := map[string]*v1beta1.Device{}
 		pcis := map[string]types.PciDevice{}
 
-		rp := accelerator.NewAccelResourcePool(rc, devs, pcis)
+		rp := accelerator.NewAccelResourcePool(rc, pcis)
 
 		It("should return a valid instance of the pool", func() {
 			Expect(rp).ToNot(BeNil())
@@ -43,7 +41,6 @@ var _ = Describe("AccelResourcePool", func() {
 				ResourceName:   "fake",
 				ResourcePrefix: "fake",
 			}
-			devs := map[string]*v1beta1.Device{}
 
 			// fake1 will have 2 device specs
 			fake1 := &mocks.AccelDevice{}
@@ -67,7 +64,7 @@ var _ = Describe("AccelResourcePool", func() {
 
 			pcis := map[string]types.PciDevice{"fake1": fake1, "fake2": fake2, "fake3": fake3}
 
-			rp := accelerator.NewAccelResourcePool(rc, devs, pcis)
+			rp := accelerator.NewAccelResourcePool(rc, pcis)
 
 			devIDs := []string{"fake1", "fake2"}
 

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/accelerator"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/netdevice"
@@ -98,11 +97,9 @@ func (rf *resourceFactory) GetSelector(attr string, values []string) (types.Devi
 // GetResourcePool returns an instance of resourcePool
 func (rf *resourceFactory) GetResourcePool(rc *types.ResourceConfig, filteredDevice []types.PciDevice) (types.ResourcePool, error) {
 	devicePool := make(map[string]types.PciDevice)
-	apiDevices := make(map[string]*pluginapi.Device)
 	for _, dev := range filteredDevice {
 		pciAddr := dev.GetPciAddr()
 		devicePool[pciAddr] = dev
-		apiDevices[pciAddr] = dev.GetAPIDevice()
 		glog.Infof("device added: [pciAddr: %s, vendor: %s, device: %s, driver: %s]",
 			dev.GetPciAddr(),
 			dev.GetVendor(),
@@ -117,7 +114,7 @@ func (rf *resourceFactory) GetResourcePool(rc *types.ResourceConfig, filteredDev
 		if len(filteredDevice) > 0 {
 			if _, ok := filteredDevice[0].(types.PciNetDevice); ok {
 				nadUtils := rf.GetNadUtils()
-				rPool = netdevice.NewNetResourcePool(nadUtils, rc, apiDevices, devicePool)
+				rPool = netdevice.NewNetResourcePool(nadUtils, rc, devicePool)
 			} else {
 				err = fmt.Errorf("invalid device list for NetDeviceType")
 			}
@@ -125,7 +122,7 @@ func (rf *resourceFactory) GetResourcePool(rc *types.ResourceConfig, filteredDev
 	case types.AcceleratorType:
 		if len(filteredDevice) > 0 {
 			if _, ok := filteredDevice[0].(types.AccelDevice); ok {
-				rPool = accelerator.NewAccelResourcePool(rc, apiDevices, devicePool)
+				rPool = accelerator.NewAccelResourcePool(rc, devicePool)
 			} else {
 				err = fmt.Errorf("invalid device list for AcceleratorType")
 			}

--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -35,9 +35,9 @@ type netResourcePool struct {
 var _ types.ResourcePool = &netResourcePool{}
 
 // NewNetResourcePool returns an instance of resourcePool
-func NewNetResourcePool(nadutils types.NadUtils, rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device,
+func NewNetResourcePool(nadutils types.NadUtils, rc *types.ResourceConfig,
 	devicePool map[string]types.PciDevice) types.ResourcePool {
-	rp := resources.NewResourcePool(rc, apiDevices, devicePool)
+	rp := resources.NewResourcePool(rc, devicePool)
 	s, _ := rc.SelectorObj.(*types.NetDeviceSelectors)
 	return &netResourcePool{
 		ResourcePoolImpl: rp,

--- a/pkg/netdevice/netResourcePool_test.go
+++ b/pkg/netdevice/netResourcePool_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/factory"
@@ -40,10 +39,9 @@ var _ = Describe("NetResourcePool", func() {
 			ResourcePrefix: "fake",
 			SelectorObj:    &types.NetDeviceSelectors{},
 		}
-		devs := map[string]*v1beta1.Device{}
 		pcis := map[string]types.PciDevice{}
 
-		rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
+		rp := netdevice.NewNetResourcePool(nadutils, rc, pcis)
 
 		It("should return a valid instance of the pool", func() {
 			Expect(rp).ToNot(BeNil())
@@ -60,7 +58,6 @@ var _ = Describe("NetResourcePool", func() {
 					IsRdma: false,
 				},
 			}
-			devs := map[string]*v1beta1.Device{}
 
 			// fake1 will have 2 device specs
 			fake1 := &mocks.PciNetDevice{}
@@ -84,7 +81,7 @@ var _ = Describe("NetResourcePool", func() {
 
 			pcis := map[string]types.PciDevice{"fake1": fake1, "fake2": fake2, "fake3": fake3}
 
-			rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
+			rp := netdevice.NewNetResourcePool(nadutils, rc, pcis)
 
 			devIDs := []string{"fake1", "fake2"}
 
@@ -110,7 +107,6 @@ var _ = Describe("NetResourcePool", func() {
 				},
 			}
 
-			devs := map[string]*v1beta1.Device{}
 			fake1 := &mocks.PciNetDevice{}
 			fake1.On("GetPciAddr").Return("0000:01:00.1").
 				On("GetVdpaDevice").Return(nil)
@@ -135,7 +131,7 @@ var _ = Describe("NetResourcePool", func() {
 						}
 						return nil
 					})
-				rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
+				rp := netdevice.NewNetResourcePool(nadutils, rc, pcis)
 				err := rp.StoreDeviceInfoFile("fakeOrg.io")
 				nadutils.AssertExpectations(t)
 				Expect(err).ToNot(HaveOccurred())
@@ -144,7 +140,7 @@ var _ = Describe("NetResourcePool", func() {
 				nadutils := &mocks.NadUtils{}
 				nadutils.On("CleanDeviceInfoFile", "fakeOrg.io/fakeResource", "fake1").Return(nil)
 				nadutils.On("CleanDeviceInfoFile", "fakeOrg.io/fakeResource", "fake2").Return(nil)
-				rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
+				rp := netdevice.NewNetResourcePool(nadutils, rc, pcis)
 				err := rp.CleanDeviceInfoFile("fakeOrg.io")
 				nadutils.AssertExpectations(t)
 				Expect(err).ToNot(HaveOccurred())
@@ -159,7 +155,6 @@ var _ = Describe("NetResourcePool", func() {
 				},
 			}
 
-			devs := map[string]*v1beta1.Device{}
 			fakeVdpa1 := &mocks.VdpaDevice{}
 			fakeVdpa1.On("GetParent").Return("vdpa1").
 				On("GetPath").Return("/dev/vhost-vdpa5").
@@ -203,7 +198,7 @@ var _ = Describe("NetResourcePool", func() {
 						}
 						return nil
 					})
-				rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
+				rp := netdevice.NewNetResourcePool(nadutils, rc, pcis)
 				err := rp.StoreDeviceInfoFile("fakeOrg.io")
 				Expect(err).ToNot(HaveOccurred())
 				nadutils.AssertExpectations(t)
@@ -212,7 +207,7 @@ var _ = Describe("NetResourcePool", func() {
 				nadutils := &mocks.NadUtils{}
 				nadutils.On("CleanDeviceInfoFile", "fakeOrg.io/fakeResource", "fake1").Return(nil)
 				nadutils.On("CleanDeviceInfoFile", "fakeOrg.io/fakeResource", "fake2").Return(nil)
-				rp := netdevice.NewNetResourcePool(nadutils, rc, devs, pcis)
+				rp := netdevice.NewNetResourcePool(nadutils, rc, pcis)
 				err := rp.CleanDeviceInfoFile("fakeOrg.io")
 				Expect(err).ToNot(HaveOccurred())
 				nadutils.AssertExpectations(t)

--- a/pkg/resources/pool_stub.go
+++ b/pkg/resources/pool_stub.go
@@ -24,18 +24,15 @@ import (
 // ResourcePoolImpl implements stub ResourcePool interface
 type ResourcePoolImpl struct {
 	config     *types.ResourceConfig
-	devices    map[string]*pluginapi.Device
 	devicePool map[string]types.PciDevice
 }
 
 var _ types.ResourcePool = &ResourcePoolImpl{}
 
 // NewResourcePool returns an instance of resourcePool
-func NewResourcePool(rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device,
-	devicePool map[string]types.PciDevice) *ResourcePoolImpl {
+func NewResourcePool(rc *types.ResourceConfig, devicePool map[string]types.PciDevice) *ResourcePoolImpl {
 	return &ResourcePoolImpl{
 		config:     rc,
-		devices:    apiDevices,
 		devicePool: devicePool,
 	}
 }
@@ -63,8 +60,11 @@ func (rp *ResourcePoolImpl) GetResourcePrefix() string {
 
 // GetDevices returns a map of Kubelet API devices
 func (rp *ResourcePoolImpl) GetDevices() map[string]*pluginapi.Device {
-	// returns all devices from devices[]
-	return rp.devices
+	devices := make(map[string]*pluginapi.Device)
+	for id, dev := range rp.devicePool {
+		devices[id] = dev.GetAPIDevice()
+	}
+	return devices
 }
 
 // Probe - does device healthcheck. Not implemented

--- a/pkg/resources/pool_stub_test.go
+++ b/pkg/resources/pool_stub_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("PoolStub", func() {
+var _ = Describe("ResourcePool", func() {
 	var (
 		fs     *utils.FakeFilesystem
 		f      types.ResourceFactory
@@ -54,7 +54,6 @@ var _ = Describe("PoolStub", func() {
 				d1, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f, rc)
 				d2, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f, rc)
 				rp = resources.NewResourcePool(rc,
-					map[string]*pluginapi.Device{},
 					map[string]types.PciDevice{
 						"0000:00:00.1": d1,
 						"0000:00:00.2": d2,
@@ -81,7 +80,6 @@ var _ = Describe("PoolStub", func() {
 				d1, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f, rc)
 				d2, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f, rc)
 				rp = resources.NewResourcePool(rc,
-					map[string]*pluginapi.Device{},
 					map[string]types.PciDevice{
 						"0000:00:00.1": d1,
 						"0000:00:00.2": d2,
@@ -104,7 +102,6 @@ var _ = Describe("PoolStub", func() {
 				d1, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f, rc)
 				d2, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f, rc)
 				rp = resources.NewResourcePool(rc,
-					map[string]*pluginapi.Device{},
 					map[string]types.PciDevice{
 						"0000:00:00.1": d1,
 						"0000:00:00.2": d2,
@@ -118,6 +115,27 @@ var _ = Describe("PoolStub", func() {
 				Expect(mounts).To(ConsistOf(expected))
 			})
 
+		})
+	})
+	Describe("GetDevices", func() {
+		It("Returns API devices for PCIDevices in the pool", func() {
+			defer fs.Use()()
+			utils.SetDefaultMockNetlinkProvider()
+
+			d1, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f, rc)
+			d2, _ = netdevice.NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f, rc)
+			rp = resources.NewResourcePool(rc,
+				map[string]types.PciDevice{
+					"0000:00:00.1": d1,
+					"0000:00:00.2": d2,
+				},
+			)
+			devices := rp.GetDevices()
+			Expect(devices).To(HaveLen(2))
+			Expect(devices).To(HaveKey("0000:00:00.1"))
+			Expect(devices).To(HaveKey("0000:00:00.2"))
+			Expect(devices["0000:00:00.1"].ID).To(Equal("0000:00:00.1"))
+			Expect(devices["0000:00:00.2"].ID).To(Equal("0000:00:00.2"))
 		})
 	})
 })


### PR DESCRIPTION
This commit removes `devices` map from ResourcePoolImpl
and uses devicePool map instead in GetDevices() method.
This is done to avoid duplication by holding API devices
in two places.

In addition, add unit-test for GetDevices().

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>