### PR TITLE
Fixed linter issues

### DIFF
--- a/pkg/netdevice/netInfoProviders.go
+++ b/pkg/netdevice/netInfoProviders.go
@@ -25,7 +25,7 @@ import (
 )
 
 /*
-   rdmaInfoProvider provides the RDMA information
+rdmaInfoProvider provides the RDMA information
 */
 type rdmaInfoProvider struct {
 	rdmaSpec types.RdmaSpec
@@ -58,7 +58,7 @@ func (rip *rdmaInfoProvider) GetMounts() []*pluginapi.Mount {
 }
 
 /*
-   VhostNetInfoProvider wraps any DeviceInfoProvider and adds a vhost-net device
+VhostNetInfoProvider wraps any DeviceInfoProvider and adds a vhost-net device
 */
 type vhostNetInfoProvider struct {
 }

--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -69,7 +69,7 @@ func (rp *netResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Devic
 }
 
 // StoreDeviceInfoFile stores the Device Info files according to the
-//  k8snetworkplumbingwg/device-info-spec
+// k8snetworkplumbingwg/device-info-spec
 func (rp *netResourcePool) StoreDeviceInfoFile(resourceNamePrefix string) error {
 	var devInfo nettypes.DeviceInfo
 	for id, dev := range rp.GetDevicePool() {

--- a/pkg/netdevice/vdpa.go
+++ b/pkg/netdevice/vdpa.go
@@ -27,8 +27,9 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 )
 
-/*vdpaTypeToDriver translates vdpaTypes (as specified in the netDevice selectors)
-  to vdpa bus drivers*/
+// vdpaTypeToDriver translates vdpaTypes (as specified in the netDevice selectors)
+// to vdpa bus drivers
+
 var supportedVdpaTypes = map[types.VdpaType]string{
 	types.VdpaVirtioType: vdpa.VirtioVdpaDriver,
 	types.VdpaVhostType:  vdpa.VhostVdpaDriver,

--- a/pkg/resources/vfioInfoProvider.go
+++ b/pkg/resources/vfioInfoProvider.go
@@ -23,7 +23,7 @@ import (
 )
 
 /*
-   vfioInfoProvider implements DeviceInfoProvider
+vfioInfoProvider implements DeviceInfoProvider
 */
 type vfioInfoProvider struct {
 	pciAddr   string

--- a/pkg/utils/ddp_test.go
+++ b/pkg/utils/ddp_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//https://npf.io/2015/06/testing-exec-command
+// https://npf.io/2015/06/testing-exec-command
 func FakeExecCommand(outs, exitCode string) func(string, ...string) *exec.Cmd {
 	return func(command string, args ...string) *exec.Cmd {
 		cs := []string{"-test.run=TestHelperProcess", "--", command}
@@ -25,7 +25,7 @@ func FakeExecCommand(outs, exitCode string) func(string, ...string) *exec.Cmd {
 	}
 }
 
-//https://npf.io/2015/06/testing-exec-command
+// https://npf.io/2015/06/testing-exec-command
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return


### PR DESCRIPTION
I've noticed that golangci-lint throws some errors (go fmt formatting) on current codebase. Fixed those quickly.