### PR TITLE
Update sriov device plugin deployment

### DIFF
--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.4.0
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest-amd64
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp
@@ -99,7 +99,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: ppc64le
+        kubernetes.io/arch: ppc64le
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
@@ -170,7 +170,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: arm64
+        kubernetes.io/arch: arm64
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
- move yaml to deployment root dir as we dont maintain yamls for multiple k8s versions
- align amd64 daemonset to deploy latest like other arch
- use kubernetes.io/arch label instead of beta.kubernetes.io/arch as it is deprecated

Signed-off-by: adrianc <adrianc@nvidia.com>