### PR TITLE
Updating alpine version to fix docker image build

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.18-alpine3.16 as builder
 
 COPY . /usr/src/sriov-network-device-plugin
 ADD images/ddptool-1.0.1.12.tar.gz /tmp/ddptool/


### PR DESCRIPTION
Tagging base image to fix issue with latest gcc version in alpine 3.17
fixes #459 

signed off: eoghan.russell@intel.com
