### PR TITLE
Move ddptool build to its own continer

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,15 +1,22 @@
 FROM golang:1.18-alpine as builder
 
 COPY . /usr/src/sriov-network-device-plugin
-ADD images/ddptool-1.0.1.12.tar.gz /tmp/ddptool/
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
-RUN apk add --no-cache --virtual build-dependencies build-base linux-headers git
+RUN apk add --no-cache --virtual build-dependencies build-base
 
 WORKDIR /usr/src/sriov-network-device-plugin
 RUN make clean && \
     make build
+
+FROM golang:1.18-alpine3.16 as ddp-builder
+
+ADD images/ddptool-1.0.1.12.tar.gz /tmp/ddptool/
+
+ENV HTTP_PROXY $http_proxy
+ENV HTTPS_PROXY $https_proxy
+RUN apk add --no-cache --virtual build-dependencies build-base linux-headers
 
 WORKDIR /tmp/ddptool
 RUN make
@@ -17,7 +24,7 @@ RUN make
 FROM alpine:3
 RUN apk add --no-cache hwdata-pci
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
-COPY --from=builder /tmp/ddptool/ddptool /usr/bin/
+COPY --from=ddp-builder /tmp/ddptool/ddptool /usr/bin/
 WORKDIR /
 
 LABEL io.k8s.display-name="SRIOV Network Device Plugin"


### PR DESCRIPTION
due to recent update of gcc in builder base image
compilation of ddptool fails.

split ddptool build to its own container and fix alpine version.

this will allow to control the base image which is used to build device plugin and ddptool separately.

once ddptool is updated, its alpine base image version can be bumped

Signed-off-by: adrianc <adrianc@nvidia.com>