### PR TITLE
Cleanup: remove ioutil for new go version

### DIFF
--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -23,7 +22,7 @@ type FakeFilesystem struct {
 // Use function creates entire files structure and returns a function to tear it down. Example usage: defer fs.Use()()
 func (fs *FakeFilesystem) Use() func() {
 	// create the new fake fs root dir in /tmp/sriov...
-	tmpDir, err := ioutil.TempDir("", "sriov")
+	tmpDir, err := os.CreateTemp("", "sriov")
 	if err != nil {
 		panic(fmt.Errorf("error creating fake root dir: %s", err.Error()))
 	}


### PR DESCRIPTION
Remove ioutil for new go version.
https://go.dev/doc/go1.16#ioutil