### PR TITLE
Remove deprecated label: beta.kubernetes.io/arch

### DIFF
--- a/docs/config-file/README.md
+++ b/docs/config-file/README.md
@@ -46,7 +46,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
The label `beta.kubernetes.io/arch` has been deprecated for a long time

