### PR TITLE
auxnetdevice: Don't skip PCI network devices with default route

### DIFF
--- a/pkg/auxnetdevice/auxNetDeviceProvider.go
+++ b/pkg/auxnetdevice/auxNetDeviceProvider.go
@@ -83,9 +83,7 @@ func (ap *auxNetDeviceProvider) AddTargetDevices(devices []*ghw.PCIDevice, devic
 			productName := utils.NormalizeProductName(device.Product.Name)
 			glog.Infof("auxnetdevice AddTargetDevices(): device found: %-12s\t%-12s\t%-20s\t%-40s", device.Address,
 				device.Class.ID, vendorName, productName)
-			if isDefaultRoute, _ := utils.HasDefaultRoute(device.Address); !isDefaultRoute {
-				ap.deviceList = append(ap.deviceList, device)
-			}
+			ap.deviceList = append(ap.deviceList, device)
 		}
 	}
 	return nil


### PR DESCRIPTION
It is legal to use auxiliary devices of system default interface.