### PR TITLE
allow dash "-" in resource name

### DIFF
--- a/cmd/sriovdp/manager_test.go
+++ b/cmd/sriovdp/manager_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Resource manager", func() {
 				}
 				err = os.WriteFile("/tmp/sriovdp/test_config", []byte(`{
 					"resourceList":	[{
-						"resourceName": "invalid-name",
+						"resourceName": "invalid.name",
 						"selectors": {
 							"isRdma": false,
 							"vendors": ["8086"],

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -273,7 +273,7 @@ func SriovConfigured(addr string) bool {
 // ValidResourceName returns true if it contains permitted characters otherwise false
 func ValidResourceName(name string) bool {
 	// name regex
-	var validString = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	var validString = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 	return validString.MatchString(name)
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -296,8 +296,8 @@ var _ = Describe("In the utils package", func() {
 		func(name string, expected bool) {
 			Expect(ValidResourceName(name)).To(Equal(expected))
 		},
-		Entry("resource name is valid", "sriov_net_0", true),
-		Entry("resource name is invalid", "junk-net-0", false),
+		Entry("resource name is valid", "sriov-net_0", true),
+		Entry("resource name is invalid", "junk.net.0", false),
 	)
 
 	DescribeTable("getting VFIO device file",


### PR DESCRIPTION
according to
https://github.com/kubernetes/kubernetes/blob/b1f901acf44f8adf69759db434690c2a8bdd616b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto#L41, resource name is expected to be a DNS lable so dash should be allowed

Fixes: #476