### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -41,7 +41,7 @@ jobs:
         run: sudo apt-get install hwdata -y
 
       - name: Go test
-        run: make test
+        run: make test-race
 
   test-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request enables race detection in unit tests by modifying the test step in build-test-lint.yml to include the '-race' flag by running  make test-race, enabling race detection in the CI during testing.

Race detection can help identifying potential data race conditions, which can lead to hard-to-debug issues in concurrent code. By enabling race detection in our unit tests, we can detect and address these race conditions, ensuring the reliability and stability of our code. (for further reference view: https://go.dev/doc/articles/race_detector)