### PR TITLE
Set container device permissions to 'rw'

### DIFF
--- a/pkg/devices/rdma.go
+++ b/pkg/devices/rdma.go
@@ -40,7 +40,7 @@ func newRdmaSpec(rdmaResources []string) types.RdmaSpec {
 				deviceSpec = append(deviceSpec, &pluginapi.DeviceSpec{
 					HostPath:      rdmaDevice,
 					ContainerPath: rdmaDevice,
-					Permissions:   "rwm",
+					Permissions:   "rw",
 				})
 			}
 		}

--- a/pkg/devices/rdma_test.go
+++ b/pkg/devices/rdma_test.go
@@ -57,27 +57,27 @@ var _ = Describe("RdmaSpec", func() {
 					{
 						ContainerPath: "/dev/infiniband/issm0",
 						HostPath:      "/dev/infiniband/issm0",
-						Permissions:   "rwm",
+						Permissions:   "rw",
 					},
 					{
 						ContainerPath: "/dev/infiniband/umad0",
 						HostPath:      "/dev/infiniband/umad0",
-						Permissions:   "rwm",
+						Permissions:   "rw",
 					},
 					{
 						ContainerPath: "/dev/infiniband/uverbs0",
 						HostPath:      "/dev/infiniband/uverbs0",
-						Permissions:   "rwm",
+						Permissions:   "rw",
 					},
 					{
 						ContainerPath: "/dev/infiniband/rdma_cm",
 						HostPath:      "/dev/infiniband/rdma_cm",
-						Permissions:   "rwm",
+						Permissions:   "rw",
 					},
 					{
 						ContainerPath: "/dev/infiniband/rdma_cm",
 						HostPath:      "/dev/infiniband/rdma_cm",
-						Permissions:   "rwm",
+						Permissions:   "rw",
 					},
 				}))
 				fakeRdmaProvider.AssertExpectations(t)

--- a/pkg/infoprovider/uioInfoProvider.go
+++ b/pkg/infoprovider/uioInfoProvider.go
@@ -51,7 +51,7 @@ func (rp *uioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 			HostPath:      uioDev,
 			ContainerPath: uioDev,
-			Permissions:   "mrw",
+			Permissions:   "rw",
 		})
 		rp.uioDev = uioDev
 	}

--- a/pkg/infoprovider/uioInfoProvider_test.go
+++ b/pkg/infoprovider/uioInfoProvider_test.go
@@ -52,7 +52,7 @@ var _ = Describe("uioInfoProvider", func() {
 			},
 			"0000:02:00.0",
 			[]*pluginapi.DeviceSpec{
-				{HostPath: "/dev/uio0", ContainerPath: "/dev/uio0", Permissions: "mrw"},
+				{HostPath: "/dev/uio0", ContainerPath: "/dev/uio0", Permissions: "rw"},
 			},
 		),
 	)

--- a/pkg/infoprovider/vdpaInfoProvider.go
+++ b/pkg/infoprovider/vdpaInfoProvider.go
@@ -64,7 +64,7 @@ func (vip *vdpaInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 			HostPath:      vdpaPath,
 			ContainerPath: vdpaPath,
-			Permissions:   "mrw",
+			Permissions:   "rw",
 		})
 		vip.vdpaPath = vdpaPath
 	}

--- a/pkg/infoprovider/vdpaInfoProvider_test.go
+++ b/pkg/infoprovider/vdpaInfoProvider_test.go
@@ -71,7 +71,7 @@ var _ = Describe("vdpaInfoProvider", func() {
 			Expect(dip.GetDeviceSpecs()).To(Equal([]*pluginapi.DeviceSpec{{
 				HostPath:      "/dev/vhost-vdpa1",
 				ContainerPath: "/dev/vhost-vdpa1",
-				Permissions:   "mrw",
+				Permissions:   "rw",
 			}}))
 		})
 	})

--- a/pkg/infoprovider/vfioInfoProvider.go
+++ b/pkg/infoprovider/vfioInfoProvider.go
@@ -51,7 +51,7 @@ func (rp *vfioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 		HostPath:      rp.vfioMount,
 		ContainerPath: rp.vfioMount,
-		Permissions:   "mrw",
+		Permissions:   "rw",
 	})
 
 	vfioDevHost, vfioDevContainer, err := utils.GetVFIODeviceFile(rp.pciAddr)
@@ -61,7 +61,7 @@ func (rp *vfioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 			HostPath:      vfioDevHost,
 			ContainerPath: vfioDevContainer,
-			Permissions:   "mrw",
+			Permissions:   "rw",
 		})
 		rp.vfioDevContainer = vfioDevContainer
 	}

--- a/pkg/infoprovider/vfioInfoProvider_test.go
+++ b/pkg/infoprovider/vfioInfoProvider_test.go
@@ -47,7 +47,7 @@ var _ = Describe("vfioInfoProvider", func() {
 			&utils.FakeFilesystem{},
 			"",
 			[]*pluginapi.DeviceSpec{
-				{HostPath: "/dev/vfio/vfio", ContainerPath: "/dev/vfio/vfio", Permissions: "mrw"},
+				{HostPath: "/dev/vfio/vfio", ContainerPath: "/dev/vfio/vfio", Permissions: "rw"},
 			},
 		),
 		Entry("PCI address passed, returns DeviceSpec with paths to its VFIO devices and additional default VFIO path",
@@ -61,8 +61,8 @@ var _ = Describe("vfioInfoProvider", func() {
 			},
 			"0000:02:00.0",
 			[]*pluginapi.DeviceSpec{
-				{HostPath: "/dev/vfio/0", ContainerPath: "/dev/vfio/0", Permissions: "mrw"},
-				{HostPath: "/dev/vfio/vfio", ContainerPath: "/dev/vfio/vfio", Permissions: "mrw"},
+				{HostPath: "/dev/vfio/0", ContainerPath: "/dev/vfio/0", Permissions: "rw"},
+				{HostPath: "/dev/vfio/vfio", ContainerPath: "/dev/vfio/vfio", Permissions: "rw"},
 			},
 		),
 	)

--- a/pkg/infoprovider/vhostNetInfoProvider.go
+++ b/pkg/infoprovider/vhostNetInfoProvider.go
@@ -49,7 +49,7 @@ func getVhostNetDeviceSpec() []*pluginapi.DeviceSpec {
 	deviceSpec = append(deviceSpec, &pluginapi.DeviceSpec{
 		HostPath:      "/dev/vhost-net",
 		ContainerPath: "/dev/vhost-net",
-		Permissions:   "mrw",
+		Permissions:   "rw",
 	})
 
 	return deviceSpec
@@ -67,7 +67,7 @@ func getTunDeviceSpec() []*pluginapi.DeviceSpec {
 	deviceSpec = append(deviceSpec, &pluginapi.DeviceSpec{
 		HostPath:      "/dev/net/tun",
 		ContainerPath: "/dev/net/tun",
-		Permissions:   "mrw",
+		Permissions:   "rw",
 	})
 
 	return deviceSpec

--- a/pkg/infoprovider/vhostNetInfoProvider_test.go
+++ b/pkg/infoprovider/vhostNetInfoProvider_test.go
@@ -40,12 +40,12 @@ var _ = Describe("vdpaInfoProvider", func() {
 				{
 					HostPath:      "/dev/vhost-net",
 					ContainerPath: "/dev/vhost-net",
-					Permissions:   "mrw",
+					Permissions:   "rw",
 				},
 				{
 					HostPath:      "/dev/net/tun",
 					ContainerPath: "/dev/net/tun",
-					Permissions:   "mrw",
+					Permissions:   "rw",
 				},
 			}))
 		})

--- a/pkg/netdevice/pciNetDevice_test.go
+++ b/pkg/netdevice/pciNetDevice_test.go
@@ -434,7 +434,7 @@ var _ = Describe("PciNetDevice", func() {
 					{
 						HostPath:      "/dev/vhost-vdpa1",
 						ContainerPath: "/dev/vhost-vdpa1",
-						Permissions:   "mrw",
+						Permissions:   "rw",
 					}}))
 				Expect(dev1.GetMounts()).To(HaveLen(0))
 				Expect(dev1.GetVdpaDevice()).To(Equal(fakeVdpaVhost))

--- a/pkg/resources/pool_stub_test.go
+++ b/pkg/resources/pool_stub_test.go
@@ -71,9 +71,9 @@ var _ = Describe("ResourcePool", func() {
 				specs := rp.GetDeviceSpecs(devs)
 
 				expected := []*pluginapi.DeviceSpec{
-					{ContainerPath: "/dev/vfio/vfio", HostPath: "/dev/vfio/vfio", Permissions: "mrw"},
-					{ContainerPath: "/dev/vfio/0", HostPath: "/dev/vfio/0", Permissions: "mrw"},
-					{ContainerPath: "/dev/vfio/1", HostPath: "/dev/vfio/1", Permissions: "mrw"},
+					{ContainerPath: "/dev/vfio/vfio", HostPath: "/dev/vfio/vfio", Permissions: "rw"},
+					{ContainerPath: "/dev/vfio/0", HostPath: "/dev/vfio/0", Permissions: "rw"},
+					{ContainerPath: "/dev/vfio/1", HostPath: "/dev/vfio/1", Permissions: "rw"},
 				}
 				Expect(specs).To(HaveLen(3))
 				Expect(specs).To(ConsistOf(expected))


### PR DESCRIPTION
There is no need to create devices inside containers, so we don't
need to add 'm' permissions.
