### PR TITLE
Recognize modern taint in demo

### DIFF
--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -32,6 +32,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp


### PR DESCRIPTION
Modern kubernetes does not set the `master` designation any longer.  This patch adds in support for `control-plane` while preserving the old behavior.