### PR TITLE
Update device plugins volumes mounts

### DIFF
--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -54,7 +54,10 @@ spec:
             memory: "200Mi"
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/
+          mountPath: /var/lib/kubelet/device-plugins
+          readOnly: false
+        - name: plugins-registry
+          mountPath: /var/lib/kubelet/plugins_registry
           readOnly: false
         - name: log
           mountPath: /var/log
@@ -65,7 +68,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
             path: /var/log
@@ -126,7 +132,10 @@ spec:
             memory: "200Mi"
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/
+          mountPath: /var/lib/kubelet/device-plugins
+          readOnly: false
+        - name: plugins-registry
+          mountPath: /var/lib/kubelet/plugins_registry
           readOnly: false
         - name: log
           mountPath: /var/log
@@ -137,7 +146,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
             path: /var/log
@@ -197,7 +209,10 @@ spec:
             memory: "200Mi"
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/
+          mountPath: /var/lib/kubelet/device-plugins
+          readOnly: false
+        - name: plugins-registry
+          mountPath: /var/lib/kubelet/plugins_registry
           readOnly: false
         - name: log
           mountPath: /var/log
@@ -208,7 +223,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
             path: /var/log

--- a/images/README.md
+++ b/images/README.md
@@ -29,7 +29,7 @@ Note: The likely best practice here is to build your own image given the Dockerf
 Example docker run command:
 
 ```
-$ docker run -it -v /var/lib/kubelet/:/var/lib/kubelet/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin
+$ docker run -it -v /var/lib/kubelet/device-plugins:/var/lib/kubelet/device-plugins -v /var/lib/kubelet/plugins_registry:/var/lib/kubelet/plugins_registry -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin
 ```
 
 Originally inspired by and is a portmanteau of the [Flannel daemonset](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml), the [Calico Daemonset](https://github.com/projectcalico/calico/blob/master/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml), and the [Calico CNI install bash script](https://github.com/projectcalico/cni-plugin/blob/be4df4db2e47aa7378b1bdf6933724bac1f348d0/k8s-install/scripts/install-cni.sh#L104-L153).


### PR DESCRIPTION
There is no need to mount the whole '/var/lib/kubelet/' directory into a pod. It's enough to mount only '/var/lib/kubelet/device-plugins' and '/var/lib/kubelet/plugins_registry' directories.