### PR TITLE
Fix can't get pfname for virtio pci path

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -92,6 +92,17 @@ func GetPfName(pciAddr string) (string, error) {
 	}
 
 	path := filepath.Join(sysBusPci, pciAddr, "physfn", "net")
+	virtIOpath := filepath.Join(sysBusPci, pciAddr, "physfn")
+	dir, err := os.ReadDir(virtIOpath)
+	if err != nil {
+		return "", fmt.Errorf("can't open path %s: %w", virtIOpath, err)
+	}
+	for _, file := range dir {
+		if strings.Contains(file.Name(), "virtio") {
+			path = filepath.Join(virtIOpath, file.Name(), "net")
+			break
+		}
+	}
 	files, err := os.ReadDir(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -432,12 +432,24 @@ var _ = Describe("In the utils package", func() {
 			&FakeFilesystem{Dirs: []string{"sys/bus/pci/devices/0000:01:10.0/physfn/net/"}},
 			"0000:01:10.0", "", true,
 		),
-		Entry("pf net is not a directory at all",
+		Entry("PF net is not a directory at all",
 			&FakeFilesystem{
 				Dirs:  []string{"sys/bus/pci/devices/0000:01:10.0/physfn"},
 				Files: map[string][]byte{"sys/bus/pci/devices/0000:01:10.0/physfn/net/": []byte("junk")},
 			},
 			"0000:01:10.0", "", true,
+		),
+		Entry("PF net is in virtio path",
+			&FakeFilesystem{
+				Dirs: []string{
+					"sys/bus/pci/devices/0000:01:00.0/",
+					"sys/bus/pci/devices/0000:01:10.0/",
+					"sys/bus/pci/devices/0000:01:00.0/virtio1/net/fakePF"},
+				Symlinks: map[string]string{
+					"sys/bus/pci/devices/0000:01:10.0/physfn": "../0000:01:00.0",
+				},
+			},
+			"0000:01:10.0", "fakePF", false,
 		),
 	)
 


### PR DESCRIPTION
Fixed issue with virtio driver by adding a conditional check for the virtio path under the PCI address, preventing errors when the pf name cannot be found. This ensures successful acquisition of vf resources.

Fixes #507