### PR TITLE
Fix image push worklow for release

### DIFF
--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -28,6 +28,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
 
@@ -68,6 +70,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
 
@@ -109,6 +113,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
 
@@ -136,6 +142,8 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=false
         tags: |
           type=ref,event=tag
 
@@ -148,7 +156,7 @@ jobs:
 
     - name: Create manifest for multi-arch images
       run: |
-        docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ steps.docker_meta.outputs.tags }} \
-        ${{ env.IMAGE_NAME }}:${{ steps.docker_meta.outputs.tags }}-amd64 \
-        ${{ env.IMAGE_NAME }}:${{ steps.docker_meta.outputs.tags }}-arm64 \
-        ${{ env.IMAGE_NAME }}:${{ steps.docker_meta.outputs.tags }}-ppc64le
+        docker buildx imagetools create -t ${{ steps.docker_meta.outputs.tags }} \
+        ${{ steps.docker_meta.outputs.tags }}-amd64 \
+        ${{ steps.docker_meta.outputs.tags }}-arm64 \
+        ${{ steps.docker_meta.outputs.tags }}-ppc64le


### PR DESCRIPTION
- disable latest tag generation in docker meta action
- remove un-needed IMAGE_NAME var from manifest creation, docker meta tags is already with the full name.