### PR TITLE
vhost-vdpa: fix env val not show

### DIFF
--- a/pkg/infoprovider/vdpaInfoProvider.go
+++ b/pkg/infoprovider/vdpaInfoProvider.go
@@ -39,6 +39,14 @@ func NewVdpaInfoProvider(vdpaType types.VdpaType, vdpaDev types.VdpaDevice) type
 		dev:      vdpaDev,
 		vdpaType: vdpaType,
 	}
+	if vdpaType == types.VdpaVhostType && vdpaDev != nil {
+		vdpaPath, err := vdpaDev.GetPath()
+		if err != nil {
+			glog.Errorf("Unexpected error when fetching the vdpa device path: %s", err)
+		}
+		vdpaInfoProvider.vdpaPath = vdpaPath
+	}
+
 	return vdpaInfoProvider
 }
 
@@ -58,20 +66,14 @@ func (vip *vdpaInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	}
 	devSpecs := make([]*pluginapi.DeviceSpec, 0)
 
-	// DeviceSpecs only required for vhost vdpa type as the
-	if vip.vdpaType == types.VdpaVhostType {
-		vdpaPath, err := vip.dev.GetPath()
-		if err != nil {
-			glog.Errorf("Unexpected error when fetching the vdpa device path: %s", err)
-			return nil
-		}
+	if vip.vdpaPath != "" {
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
-			HostPath:      vdpaPath,
-			ContainerPath: vdpaPath,
+			HostPath:      vip.vdpaPath,
+			ContainerPath: vip.vdpaPath,
 			Permissions:   "rw",
 		})
-		vip.vdpaPath = vdpaPath
 	}
+
 	return devSpecs
 }
 

--- a/pkg/infoprovider/vdpaInfoProvider_test.go
+++ b/pkg/infoprovider/vdpaInfoProvider_test.go
@@ -86,7 +86,6 @@ var _ = Describe("vdpaInfoProvider", func() {
 			vdpa.On("GetType").Return(types.VdpaVhostType).
 				On("GetPath").Return("/dev/vhost-vdpa1", nil)
 			dip := infoprovider.NewVdpaInfoProvider(types.VdpaVhostType, vdpa)
-			dip.GetDeviceSpecs()
 			envs := dip.GetEnvVal()
 			Expect(len(envs)).To(Equal(1))
 			mount, exist := envs["mount"]


### PR DESCRIPTION
```golang
func (rs *resourceServer) Allocate(ctx context.Context, rqt *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
	glog.Infof("Allocate() called with %+v", rqt)
	resp := new(pluginapi.AllocateResponse)

	for _, container := range rqt.ContainerRequests {
		containerResp := new(pluginapi.ContainerAllocateResponse)

		envs, err := rs.getEnvs(container.DevicesIDs)
		if err != nil {
			glog.Errorf("failed to get environment variables for device IDs %v: %v", container.DevicesIDs, err)
			return nil, err
		}

		if rs.useCdi {
			containerResp.Annotations, err = rs.cdi.CreateContainerAnnotations(
				container.DevicesIDs, rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
			if err != nil {
				return nil, fmt.Errorf("can't create container annotation: %s", err)
			}
		} else {
			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(container.DevicesIDs)
			containerResp.Mounts = rs.resourcePool.GetMounts(container.DevicesIDs)
		}

		containerResp.Envs = envs
		resp.ContainerResponses = append(resp.ContainerResponses, containerResp)
	}
	glog.Infof("AllocateResponse send: %+v", resp)
	return resp, nil
}
```
In the Allocate implementation, getEnvs comes first and GetDeviceSpecs comes second.
But the GetEnvVal implementation of vdpaInfoProvider has vdpaPath assigned after the GetDeviceSpecs call.
```golang
// GetDeviceSpecs returns the DeviceSpec slice
func (vip *vdpaInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
	if healthy, err := vip.isHealthy(); !healthy {
		glog.Errorf("GetDeviceSpecs(): vDPA is required in the configuration but device does not have a healthy vdpa device: %s",
			err)
		return nil
	}
	devSpecs := make([]*pluginapi.DeviceSpec, 0)

	// DeviceSpecs only required for vhost vdpa type as the
	if vip.vdpaType == types.VdpaVhostType {
		vdpaPath, err := vip.dev.GetPath()
		if err != nil {
			glog.Errorf("Unexpected error when fetching the vdpa device path: %s", err)
			return nil
		}
		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
			HostPath:      vdpaPath,
			ContainerPath: vdpaPath,
			Permissions:   "rw",
		})
		vip.vdpaPath = vdpaPath
	}
	return devSpecs
}

// GetEnvVal returns the environment variable value
func (vip *vdpaInfoProvider) GetEnvVal() types.AdditionalInfo {
	envs := make(map[string]string, 0)
	if vip.vdpaPath != "" {
		envs["mount"] = vip.vdpaPath
	}

	return envs
}
```
This causes the vDPA device to be missing this environment variable the first time it is assigned, as follows:
**PCIDEVICE_JAGUARMICRO_COM_JAGUAR_INFO={"0000:68:00.1":{"generic":{"deviceID":"0000:68:00.1"},"vdpa":{}}}**
This can sometimes occur if multiple vDPA devices are requested(0000:68:00.1 has already been allocated once and 0000:68:00.2 is the first allocation):
**PCIDEVICE_JAGUARMICRO_COM_JAGUAR_INFO={"0000:68:00.1":{"generic":{"deviceID":"0000:68:00.1"},"vdpa":{"mount":"/dev/vhost-vdpa-0"}},"0000:68:00.2":{"generic":{"deviceID":"0000:68:00.2"},"vdpa":{}}}**

This PR solves the above problem.
