### PR TITLE
Add fallback to get PF Name for AuxNetDevice

### DIFF
--- a/pkg/devices/gen_net.go
+++ b/pkg/devices/gen_net.go
@@ -59,10 +59,11 @@ func NewGenNetDevice(deviceID string, dt types.DeviceType, isRdma bool) (*GenNet
 		}
 		netNames, _ = utils.GetNetNames(deviceID)
 	case types.AuxNetDeviceType:
-		if pfName, err = utils.GetSriovnetProvider().GetUplinkRepresentorFromAux(deviceID); err != nil {
+		if pfName, err = utils.GetPfNameFromAuxDev(deviceID); err != nil {
 			// AuxNetDeviceType by design should have PF, return error if failed to get PF name
 			return nil, err
 		}
+
 		if pfAddr, err = utils.GetSriovnetProvider().GetPfPciFromAux(deviceID); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In case we fail to get Uplink Representor, fallback to get PF PCI address and use sysfs to get PF netdevice.

This is needed in case a device supports the creation of Auxiliary devices but is not in switchdev.