### PR TITLE
Expose RDMA device name in the devicespec if available

### DIFF
--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/resources"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 )
 
 type netResourcePool struct {
@@ -112,6 +113,15 @@ func (rp *netResourcePool) StoreDeviceInfoFile(resourceNamePrefix string) error 
 				Pci: &nettypes.PciDevice{
 					PciAddress: netDev.GetPciAddr(),
 				},
+			}
+
+			if netDev.IsRdma() {
+				rdmaDevices := utils.GetRdmaProvider().GetRdmaDevicesForPcidev(devInfo.Pci.PciAddress)
+				if len(rdmaDevices) == 0 {
+					glog.Errorf("No RDMA devices available for RDMA capable device: %s", devInfo.Pci.PciAddress)
+				} else {
+					devInfo.Pci.RdmaDevice = strings.Join(rdmaDevices, ",")
+				}
 			}
 		}
 		resource := fmt.Sprintf("%s/%s", resourceNamePrefix, rp.GetConfig().ResourceName)


### PR DESCRIPTION
The DeviceInfoSpec allows to specify rdma device for a pci device: https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/blob/master/pkg/apis/k8s.cni.cncf.io/v1/types.go#L63

Multus propagates device spec to the network-status, so it's easy to track which RDMA device is allocated to a POD:
```
k8s.v1.cni.cncf.io/network-status:
	[{
		"name": "k8s-pod-network",
		"ips": [
			"192.168.107.206"
		],
		"default": true,
		"dns": {}
	},{
		"name": "default/sriov-net1",
		"interface": "net1",
		"ips": [
			"10.56.217.2"
		],
		"mac": "7a:bb:87:d9:b4:94",
		"dns": {},
		"device-info": {
			"type": "pci",
			"version": "1.1.0",
			"pci": {
				"pci-address": "0000:03:00.3",
				"rdma-device": "mlx5_4"
			}
		},
		"gateway": [
			"\u003cnil\u003e"
		]
	}]
```
This change can serve two purposes:
1. Simplify debugging. Users can just query pod's network status and understand which RDMA device belongs to which network
2. Allow applications in multi-network pods to understand, which RDMA device they should use.