### PR TITLE
Revert "🌱 Making workflows not run on forks."

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Go test with coverage
         run: make test-coverage
-
+      
       - name: Coveralls
         uses: coverallsapp/github-action@1.1.3
         with:

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -3,11 +3,8 @@ on:
   push:
     branches:
       - master
-env:
-  image-push-owner: 'k8snetworkplumbingwg'
 jobs:
   build-and-push-amd64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push AMD64
     runs-on: ubuntu-20.04
     env:
@@ -38,7 +35,6 @@ jobs:
           file: images/Dockerfile
 
   build-and-push-arm64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ARM64
     runs-on: ubuntu-20.04
     env:
@@ -71,7 +67,6 @@ jobs:
           file: images/Dockerfile.arm64
 
   build-and-push-ppc64le-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ppc64le
     runs-on: ubuntu-20.04
     env:
@@ -104,7 +99,6 @@ jobs:
           file: images/Dockerfile.ppc64le
 
   push-manifest:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     runs-on: ubuntu-20.04
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -3,11 +3,8 @@ on:
   push:
     tags:
       - v*
-env:
-  image-push-owner: 'k8snetworkplumbingwg'
 jobs:
   build-and-push-amd64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push AMD64
     runs-on: ubuntu-20.04
     env:
@@ -47,7 +44,6 @@ jobs:
           file: images/Dockerfile
 
   build-and-push-arm64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ARM64
     runs-on: ubuntu-20.04
     env:
@@ -91,7 +87,6 @@ jobs:
           file: images/Dockerfile.arm64
 
   build-and-push-ppc64le-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ppc64le
     runs-on: ubuntu-20.04
     env:
@@ -134,7 +129,6 @@ jobs:
           file: images/Dockerfile.ppc64le
 
   push-manifest:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     runs-on: ubuntu-20.04
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
Reverts k8snetworkplumbingwg/sriov-network-device-plugin#540

as it breaks the image push actions
https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/actions/runs/9091929799

```
[Invalid workflow file: .github/workflows/image-push-master.yml#L10](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/actions/runs/9091929799/workflow)
The workflow is not valid. .github/workflows/image-push-master.yml (Line: 10, Col: 9): Unrecognized named-value: 'env'. Located at position 28 within expression: github.repository_owner == env.image-push-owner .github/workflows/image-push-master.yml (Line: 41, Col: 9): Unrecognized named-value: 'env'. Located at position 28 within expression: github.repository_owner == env.image-push-owner
```

Looks like `jobs.<job_id>.if ` does not have access to the `env` context
https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability

cc @adilGhaffarDev , @Eoghan1232 , @SchSeba 