### PR TITLE
🐛  Fixes workflow scripts

### DIFF
--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -7,7 +7,6 @@ env:
   image-push-owner: 'k8snetworkplumbingwg'
 jobs:
   build-and-push-amd64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push AMD64
     runs-on: ubuntu-20.04
     env:
@@ -27,6 +26,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push sriov-network-device-plugin
+        if: ${{ github.repository_owner == env.image-push-owner }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -38,7 +38,6 @@ jobs:
           file: images/Dockerfile
 
   build-and-push-arm64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ARM64
     runs-on: ubuntu-20.04
     env:
@@ -61,6 +60,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push sriov-network-device-plugin
+        if: ${{ github.repository_owner == env.image-push-owner }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -71,7 +71,6 @@ jobs:
           file: images/Dockerfile.arm64
 
   build-and-push-ppc64le-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ppc64le
     runs-on: ubuntu-20.04
     env:
@@ -94,6 +93,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push sriov-network-device-plugin
+        if: ${{ github.repository_owner == env.image-push-owner }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -104,7 +104,6 @@ jobs:
           file: images/Dockerfile.ppc64le
 
   push-manifest:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     runs-on: ubuntu-20.04
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -7,7 +7,6 @@ env:
   image-push-owner: 'k8snetworkplumbingwg'
 jobs:
   build-and-push-amd64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push AMD64
     runs-on: ubuntu-20.04
     env:
@@ -37,6 +36,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push sriov-network-device-plugin
+        if: ${{ github.repository_owner == env.image-push-owner }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -47,7 +47,6 @@ jobs:
           file: images/Dockerfile
 
   build-and-push-arm64-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ARM64
     runs-on: ubuntu-20.04
     env:
@@ -81,6 +80,7 @@ jobs:
 
 
       - name: Build and push sriov-network-device-plugin
+        if: ${{ github.repository_owner == env.image-push-owner }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -91,7 +91,6 @@ jobs:
           file: images/Dockerfile.arm64
 
   build-and-push-ppc64le-device-plugin:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     name: Image push ppc64le
     runs-on: ubuntu-20.04
     env:
@@ -124,6 +123,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push sriov-network-device-plugin
+        if: ${{ github.repository_owner == env.image-push-owner }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -134,16 +134,17 @@ jobs:
           file: images/Dockerfile.ppc64le
 
   push-manifest:
-    if: ${{ github.repository_owner == env.image-push-owner }}
     runs-on: ubuntu-20.04
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}
     needs: [build-and-push-amd64-device-plugin,build-and-push-arm64-device-plugin,build-and-push-ppc64le-device-plugin]
     steps:
     - name: Set up Docker Buildx
+      if: ${{ github.repository_owner == env.image-push-owner }}
       uses: docker/setup-buildx-action@v2
 
     - name: Docker meta
+      if: ${{ github.repository_owner == env.image-push-owner }}
       id: docker_meta
       uses: docker/metadata-action@v4
       with:
@@ -154,6 +155,7 @@ jobs:
           type=ref,event=tag
 
     - name: Login to GitHub Container Registry
+      if: ${{ github.repository_owner == env.image-push-owner }}
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
@@ -161,6 +163,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create manifest for multi-arch images
+      if: ${{ github.repository_owner == env.image-push-owner }}
       run: |
         docker buildx imagetools create -t ${{ steps.docker_meta.outputs.tags }} \
         ${{ steps.docker_meta.outputs.tags }}-amd64 \


### PR DESCRIPTION
this PR fixes: https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/540 
it was breaking image push with following error:

```
[Invalid workflow file: .github/workflows/image-push-master.yml#L10](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/actions/runs/9091929799/workflow)
The workflow is not valid. .github/workflows/image-push-master.yml (Line: 10, Col: 9): Unrecognized named-value: 'env'. Located at position 28 within expression: github.repository_owner == env.image-push-owner .github/workflows/image-push-master.yml (Line: 41, Col: 9): Unrecognized named-value: 'env'. Located at position 28 within expression: github.repository_owner == env.image-push-owner
```

This PR has moved the `if ` further in the tree where `env`  is accessible. 
