### PR TITLE
Build with go `v1.22`

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -5,7 +5,7 @@ jobs:
     name: build
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         goarch: [amd64]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - uses: actions/checkout@v3
 
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -113,7 +113,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     # if this fails, run go mod tidy
     - name: Check if module files are consistent with code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/sriov-network-device-plugin
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Mellanox/rdmamap v1.1.0

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 COPY . /usr/src/sriov-network-device-plugin
 


### PR DESCRIPTION
Updating the build to go v1.22 is a requirement
for bumping to `k8s.io/kubelet@v1.30`

needed for:
- https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/562