### PR TITLE
Bump `actions/upload-artifact@v4`

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -148,7 +148,7 @@ jobs:
         env:
           LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE: ghaction-sriov-network-device-plugin:pr-${{github.event.pull_request.number}}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ env.TEST_REPORT_PATH }}


### PR DESCRIPTION
This fixes

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`
```


https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/actions/runs/13287834864/job/37388698220?pr=628