### PR TITLE
Fixes #648 Added a fatal log to exit on server failure

### DIFF
--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -179,6 +179,7 @@ func (rs *resourceServer) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.
 	if err := stream.Send(resp); err != nil {
 		glog.Errorf("%s: error: cannot update device states: %v\n", methodID, err)
 		rs.grpcServer.Stop()
+		glog.Fatal(err)
 		return err
 	}
 


### PR DESCRIPTION
This PR addresses an issue where the SR-IOV device plugin's gRPC server exits when an error is encountered during the ListAndWatch operation, leading to false reporting of zero available Mellanox SR-IOV VFIO resources. This behavior causes affected nodes to become unavailable for workload scheduling.

To improve resilience, the gRPC server is now configured gracefully exit using glog.Fatal() instead of just stopping the server and the expectation is that this triggers a to restart. This ensures the plugin can recover and continue reporting resources accurately, reducing the risk of node exclusion due to transient errors.

Context
The change is based on the behavior observed in the upstream implementation:
[Original exit behavior](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/15ceeb3245f35a2d4a66a802d27b4ee8f81d24f5/pkg/resources/server.go#L174)
[Proposed restart pattern ](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/15ceeb3245f35a2d4a66a802d27b4ee8f81d24f5/pkg/resources/server.go#L29)