### PR TITLE
fix: dont stop grpc server on send failure in ListAndWatch

### DIFF
--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -178,7 +178,6 @@ func (rs *resourceServer) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.
 	glog.Infof("%s: send devices %v\n", methodID, resp)
 	if err := stream.Send(resp); err != nil {
 		glog.Errorf("%s: error: cannot update device states: %v\n", methodID, err)
-		rs.grpcServer.Stop()
 		return err
 	}
 


### PR DESCRIPTION
in case of failure to send, return error. client (kubelet) can then retry.