### PR TITLE
Fixes #648 Return an err on transient failures rather than stopping the server to allow for retry

### DIFF
--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -178,7 +178,6 @@ func (rs *resourceServer) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.
 	glog.Infof("%s: send devices %v\n", methodID, resp)
 	if err := stream.Send(resp); err != nil {
 		glog.Errorf("%s: error: cannot update device states: %v\n", methodID, err)
-		rs.grpcServer.Stop()
 		return err
 	}
 


### PR DESCRIPTION
This PR addresses an issue where the SR-IOV device plugin's gRPC server would terminate unexpectedly due to a transient error during the ListAndWatch operation. This premature shutdown led to false reporting of zero available Mellanox SR-IOV VFIO resources, causing affected nodes to be marked as unschedulable.

### To improve resilience:
The gRPC server no longer stops the server when a transient error occurs when it attempts to advertise resources.
Instead, the error is logged, and an err is returned allowing the server to continue running and giving the device plugin an opportunity to recover through the kubelet's  retry.
Additionally, the Watch method already includes this code https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/5cc9452448734b5ca01c7441f3de9a2ba48f4724/pkg/resources/server.go#L343, which attempts recovery before ultimately terminating the server if retries fail. This ensures the plugin has a chance to recover from transient issues and continue reporting resources accurately, reducing the risk of node exclusion due to temporary failures, even in scenarios where the kubelet is down and a race condition is suspected.