### PR TITLE
Explicitly set hostUsers

### DIFF
--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
+      hostUsers: true
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp


### PR DESCRIPTION
The daemons require host privileges. Setting this explicitly both documents the incompatibility with user namespaces and ensures, if the default changes, the daemonset will continue to function as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the DaemonSet deployment configuration to use the host user namespace, improving compatibility with host-level operations.
  * No container security context changes were introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->