### PR TITLE
Set networkPolicy to drop all

### DIFF
--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -76,3 +76,21 @@ spec:
             items:
             - key: config.json
               path: config.json
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      name: sriov-device-plugin
+      tier: node
+      app: sriovdp
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []


### PR DESCRIPTION
Since this neither produces no consumes network traffic, it should be safe to drop everything right?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network isolation policy for SR-IOV device plugin pods, establishing network access controls and traffic restrictions within the cluster infrastructure. The policy governs incoming and outgoing communications for these infrastructure components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->