### PR TITLE
Fix VFIO device path missing from env variables

### DIFF
--- a/pkg/infoprovider/vfioInfoProvider.go
+++ b/pkg/infoprovider/vfioInfoProvider.go
@@ -26,9 +26,8 @@ import (
 vfioInfoProvider implements DeviceInfoProvider
 */
 type vfioInfoProvider struct {
-	pciAddr          string
-	vfioMount        string
-	vfioDevContainer string
+	pciAddr   string
+	vfioMount string
 }
 
 // NewVfioInfoProvider create instance of VFIO DeviceInfoProvider
@@ -63,7 +62,6 @@ func (rp *vfioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 			ContainerPath: vfioDevContainer,
 			Permissions:   "rw",
 		})
-		rp.vfioDevContainer = vfioDevContainer
 	}
 
 	return devSpecs
@@ -72,8 +70,12 @@ func (rp *vfioInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 func (rp *vfioInfoProvider) GetEnvVal() types.AdditionalInfo {
 	envs := make(map[string]string, 0)
 	envs["mount"] = "/dev/vfio/vfio"
-	if rp.vfioDevContainer != "" {
-		envs["dev-mount"] = rp.vfioDevContainer
+
+	_, vfioDevContainer, err := utils.GetVFIODeviceFile(rp.pciAddr)
+	if err != nil {
+		glog.Errorf("GetEnvVal(): error getting vfio device file for device: %s, %s", rp.pciAddr, err.Error())
+	} else {
+		envs["dev-mount"] = vfioDevContainer
 	}
 
 	return envs

--- a/pkg/infoprovider/vfioInfoProvider_test.go
+++ b/pkg/infoprovider/vfioInfoProvider_test.go
@@ -72,7 +72,7 @@ var _ = Describe("vfioInfoProvider", func() {
 		})
 	})
 	Describe("getting env val", func() {
-		It("should return passed PCI address and vfio device mount", func() {
+		It("should return vfio devices mounts", func() {
 			pciAddr := "0000:02:00.0"
 			fs := &utils.FakeFilesystem{
 				Dirs: []string{
@@ -85,7 +85,6 @@ var _ = Describe("vfioInfoProvider", func() {
 			defer fs.Use()()
 
 			dip := infoprovider.NewVfioInfoProvider(pciAddr)
-			dip.GetDeviceSpecs()
 			envs := dip.GetEnvVal()
 			Expect(envs).To(HaveLen(2))
 			devMount, exist := envs["dev-mount"]
@@ -94,6 +93,46 @@ var _ = Describe("vfioInfoProvider", func() {
 			vfioMount, exist := envs["mount"]
 			Expect(exist).To(BeTrue())
 			Expect(vfioMount).To(Equal("/dev/vfio/vfio"))
+		})
+		It("should return only mount when VFIO device file lookup fails", func() {
+			dip := infoprovider.NewVfioInfoProvider("nonexistent")
+			envs := dip.GetEnvVal()
+			Expect(envs).To(HaveLen(1))
+			_, exist := envs["dev-mount"]
+			Expect(exist).To(BeFalse())
+			vfioMount, exist := envs["mount"]
+			Expect(exist).To(BeTrue())
+			Expect(vfioMount).To(Equal("/dev/vfio/vfio"))
+		})
+		It("should compute VFIO device file on the fly and reflect filesystem changes", func() {
+			pciAddr := "0000:02:00.0"
+			dip := infoprovider.NewVfioInfoProvider(pciAddr)
+
+			fs1 := &utils.FakeFilesystem{
+				Dirs: []string{
+					"sys/bus/pci/devices/0000:02:00.0", "sys/kernel/iommu_groups/5",
+				},
+				Symlinks: map[string]string{
+					"sys/bus/pci/devices/0000:02:00.0/iommu_group": "../../../../kernel/iommu_groups/5",
+				},
+			}
+			cleanup1 := fs1.Use()
+			envs := dip.GetEnvVal()
+			Expect(envs["dev-mount"]).To(Equal("/dev/vfio/5"))
+			cleanup1()
+
+			fs2 := &utils.FakeFilesystem{
+				Dirs: []string{
+					"sys/bus/pci/devices/0000:02:00.0", "sys/kernel/iommu_groups/10",
+				},
+				Symlinks: map[string]string{
+					"sys/bus/pci/devices/0000:02:00.0/iommu_group": "../../../../kernel/iommu_groups/10",
+				},
+			}
+			cleanup2 := fs2.Use()
+			envs = dip.GetEnvVal()
+			Expect(envs["dev-mount"]).To(Equal("/dev/vfio/10"))
+			cleanup2()
 		})
 	})
 })


### PR DESCRIPTION
The vfioInfoProvider was not including the VFIO device path (e.g., /dev/vfio/162) in the environment variables because GetEnvVal() was called before GetDeviceSpecs() during allocation.

The VFIO device file path was computed in GetDeviceSpecs() and stored in vfioDevContainer, but since GetEnvVal() runs first in the Allocate() flow, the field was always empty when building env vars.

Fix: Move the VFIO device file computation to the constructor (NewVfioInfoProvider) so the values are available immediately for both GetEnvVal() and GetDeviceSpecs() regardless of call order.

Before: {"vfio":{"mount":"/dev/vfio/vfio"}}
After:  {"vfio":{"mount":"/dev/vfio/vfio","dev-mount":"/dev/vfio/162"}}