### PR TITLE
Add dedicated tmpfs volume for /tmp and enhanced security

### DIFF
--- a/deployments/cdi/sriovdp-daemonset.yaml
+++ b/deployments/cdi/sriovdp-daemonset.yaml
@@ -55,7 +55,21 @@ spec:
         - --log-level=10
         - --use-cdi
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            add:
+              - BPF
+              - IPC_LOCK
+              - NET_ADMIN
+              - NET_RAW
+              - SYS_ADMIN
+              - SYS_PTRACE
+              - SYS_RAWIO
+            drop:
+              - ALL
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
         resources:
           requests:
             cpu: "250m"

--- a/deployments/cdi/sriovdp-daemonset.yaml
+++ b/deployments/cdi/sriovdp-daemonset.yaml
@@ -64,6 +64,8 @@ spec:
             cpu: 1
             memory: "200Mi"
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: devicesock
           mountPath: /var/lib/kubelet/device-plugins
         - name: plugins-registry
@@ -77,6 +79,9 @@ spec:
         - name: dynamic-cdi
           mountPath: /var/run/cdi
       volumes:
+      - name: tmp
+        emptyDir:
+          sizeLimit: 32Mi
       - name: devicesock
         hostPath:
           path: /var/lib/kubelet/device-plugins

--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -35,7 +35,21 @@ spec:
         - --log-dir=sriovdp
         - --log-level=10
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            add:
+              - BPF
+              - IPC_LOCK
+              - NET_ADMIN
+              - NET_RAW
+              - SYS_ADMIN
+              - SYS_PTRACE
+              - SYS_RAWIO
+            drop:
+              - ALL
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
         resources:
           requests:
             cpu: "250m"

--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -44,6 +44,8 @@ spec:
             cpu: 1
             memory: "200Mi"
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: devicesock
           mountPath: /var/lib/kubelet/device-plugins
           readOnly: false
@@ -57,6 +59,9 @@ spec:
         - name: device-info
           mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
       volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi
         - name: devicesock
           hostPath:
             path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
My site security audit complained that I didn't have a dedicated `/tmp` volume.

I've also added a second commit that reduces the privilege set.