### PR TITLE
Implement persistent logging for sriov-config-device-plugin

### DIFF
--- a/cmd/sriovdp/main.go
+++ b/cmd/sriovdp/main.go
@@ -21,10 +21,15 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/logging"
 )
 
 const (
 	defaultConfig = "/etc/pcidp/config.json"
+	defaultLogMaxSize = 100
+	defaultLogMaxFiles = 5
+	defaultLogMaxAge = 30
 )
 
 // flagInit parse command line flags
@@ -35,12 +40,52 @@ func flagInit(cp *cliParams) {
 		"resource name prefix used for K8s extended resource")
 	flag.BoolVar(&cp.useCdi, "use-cdi", false,
 		"Use Container Device Interface to expose devices in containers")
+	flag.IntVar(&cp.logMaxSize, "log-max-size", defaultLogMaxSize,
+		"Maximum size in MB of a log file before rotation")
+	flag.IntVar(&cp.logMaxFiles, "log-max-files", defaultLogMaxFiles,
+		"Maximum number of old rotated log files to retain")
+	flag.IntVar(&cp.logMaxAge, "log-max-age", defaultLogMaxAge,
+		"Maximum number of days to retain old log files")
 }
+
+func configureGlogDefaults() {
+	if f := flag.Lookup("logtostderr"); f != nil && f.Value.String() != "true" {
+		if err := flag.Set("logtostderr", "true"); err != nil {
+			glog.Warningf("failed to set logtostderr=true: %v", err)
+		}
+	}
+	if f := flag.Lookup("alsologtostderr"); f != nil && f.Value.String() != "false" {
+		if err := flag.Set("alsologtostderr", "false"); err != nil {
+			glog.Warningf("failed to set alsologtostderr=false: %v", err)
+		}
+	}
+}
+
 
 func main() {
 	cp := &cliParams{}
 	flagInit(cp)
 	flag.Parse()
+	configureGlogDefaults()
+
+	logCfg := logging.Config{
+		LogDir:     logging.DefaultConfig().LogDir,
+		MaxSizeMB:  cp.logMaxSize,
+		MaxFiles:   cp.logMaxFiles,
+		MaxAgeDays: cp.logMaxAge,
+		Compress:   true,
+	}
+	if cleanupLog := logging.SetupLogRotation(logCfg); cleanupLog != nil {
+		defer cleanupLog()
+	}
+	defer glog.Flush()
+
+	logging.LogStartupHeader(logging.StartupInfo{
+		ConfigFile:     cp.configFile,
+		ResourcePrefix: cp.resourcePrefix,
+		UseCdi:         cp.useCdi,
+	})
+
 	rm := newResourceManager(cp)
 
 	glog.Infof("resource manager reading configs")

--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -37,6 +37,9 @@ type cliParams struct {
 	configFile     string
 	resourcePrefix string
 	useCdi         bool
+	logMaxSize     int
+	logMaxFiles    int
+	logMaxAge      int
 }
 
 // resourceManager manages resources for SR-IOV Network Device Plugin binaries

--- a/deployments/cdi/sriovdp-daemonset.yaml
+++ b/deployments/cdi/sriovdp-daemonset.yaml
@@ -51,7 +51,7 @@ spec:
         image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
         imagePullPolicy: IfNotPresent
         args:
-        - --log-dir=sriovdp
+        - --log_dir=/var/log/sriovdp
         - --log-level=10
         - --use-cdi
         securityContext:

--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
         imagePullPolicy: IfNotPresent
         args:
-        - --log-dir=sriovdp
+        - --log_dir=/var/log/sriovdp
         - --log-level=10
         securityContext:
           privileged: true

--- a/docs/config-file/README.md
+++ b/docs/config-file/README.md
@@ -57,7 +57,7 @@ spec:
         image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
         imagePullPolicy: IfNotPresent
         args:
-        - --log-dir=sriovdp
+        - --log_dir=/var/log/sriovdp
         - --log-level=10
         - --config-file=/etc/pcidp/$(NODE_NAME)
         env:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
+	golang.org/x/sys v0.43.0
 	google.golang.org/grpc v1.81.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	k8s.io/kubelet v0.34.3
 )
 
@@ -60,7 +62,6 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -649,6 +649,8 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -3,12 +3,15 @@
 set -e
 
 SRIOV_DP_SYS_BINARY_DIR="/usr/bin/"
+CLI_PARAMS=""
 LOG_DIR=""
 LOG_LEVEL=10
 RESOURCE_PREFIX=""
 CONFIG_FILE=""
-CLI_PARAMS=""
 USE_CDI=false
+LOG_MAX_SIZE=""
+LOG_MAX_FILES=""
+LOG_MAX_AGE=""
 
 usage()
 {
@@ -16,8 +19,11 @@ usage()
     /bin/echo -e ""
     /bin/echo -e "./entrypoint.sh"
     /bin/echo -e "\t-h --help"
-    /bin/echo -e "\t--log-dir=$LOG_DIR"
+    /bin/echo -e "\t--log_dir=/var/log/sriovdp"
     /bin/echo -e "\t--log-level=$LOG_LEVEL"
+    /bin/echo -e "\t--log-max-size=<MB> (default: 100)"
+    /bin/echo -e "\t--log-max-files=<count> (default: 5)"
+    /bin/echo -e "\t--log-max-age=<days> (default: 30)"
     /bin/echo -e "\t--resource-prefix=$RESOURCE_PREFIX"
     /bin/echo -e "\t--config-file=$CONFIG_FILE"
     /bin/echo -e "\t--use-cdi"
@@ -31,11 +37,20 @@ while [ "$1" != "" ]; do
             usage
             exit
             ;;
-        --log-dir)
+        --log_dir)
             LOG_DIR=$VALUE
             ;;
         --log-level)
             LOG_LEVEL=$VALUE
+            ;;
+        --log-max-size)
+            LOG_MAX_SIZE=$VALUE
+            ;;
+        --log-max-files)
+            LOG_MAX_FILES=$VALUE
+            ;;
+        --log-max-age)
+            LOG_MAX_AGE=$VALUE
             ;;
         --resource-prefix)
             RESOURCE_PREFIX=$VALUE
@@ -55,14 +70,75 @@ while [ "$1" != "" ]; do
     shift
 done
 
+if [ "$LOG_DIR" != "" ]; then
+    if printf '%s' "$LOG_DIR" | grep -qP '[\x00-\x1f\x7f]'; then
+        echo "ERROR: --log_dir contains control characters" >&2; exit 1
+    fi
+    case "$LOG_DIR" in
+        -*)
+            echo "ERROR: --log_dir must not start with -" >&2; exit 1 ;;
+    esac
+    if printf '%s' "$LOG_DIR" | grep -q '[[:space:]]'; then
+        echo "ERROR: --log_dir must not contain whitespace" >&2; exit 1
+    fi
+    case "$LOG_DIR" in
+        *"'"*|*\"*)
+            echo "ERROR: --log_dir must not contain quote characters" >&2; exit 1 ;;
+    esac
+    case "$LOG_DIR" in
+        *[\*\?\`\$\|\&\;\!\(\)\{\}\[\]]*)
+            echo "ERROR: --log_dir contains forbidden shell metacharacters" >&2; exit 1 ;;
+    esac
+    case "$LOG_DIR" in
+        *..*)
+            echo "ERROR: --log_dir must not contain '..'" >&2; exit 1 ;;
+    esac
+    case "$LOG_DIR" in
+        *~*)
+            echo "ERROR: --log_dir must not contain '~'" >&2; exit 1 ;;
+    esac
+    case "$LOG_DIR" in
+        /var/log|/var/log/*)
+            ;;
+        *)
+            echo "ERROR: --log_dir must be an absolute path under /var/log (got: $LOG_DIR)" >&2
+            exit 1
+            ;;
+    esac
+
+    mkdir -p "$LOG_DIR" || { echo "ERROR: cannot create log directory $LOG_DIR" >&2; exit 1; }
+
+    # Resolve symlinks and confirm the real path is still under /var/log.
+    REAL_LOG_PATH="$(cd "$LOG_DIR" && pwd -P)"
+    case "$REAL_LOG_PATH" in
+        /var/log|/var/log/*)
+            LOG_DIR="$REAL_LOG_PATH"
+            ;;
+        *)
+            echo "ERROR: --log_dir resolves to $REAL_LOG_PATH which is outside /var/log/" >&2
+            exit 1
+            ;;
+    esac
+fi
 CLI_PARAMS="-v $LOG_LEVEL"
 
 if [ "$LOG_DIR" != "" ]; then
-    mkdir -p "/var/log/$LOG_DIR"
-    CLI_PARAMS="$CLI_PARAMS --log_dir /var/log/$LOG_DIR --alsologtostderr"
+    CLI_PARAMS="$CLI_PARAMS --logtostderr --log_dir=$LOG_DIR"
 else
     CLI_PARAMS="$CLI_PARAMS --logtostderr"
 fi
+
+for spec in \
+    "--log-max-size:$LOG_MAX_SIZE" \
+    "--log-max-files:$LOG_MAX_FILES" \
+    "--log-max-age:$LOG_MAX_AGE"
+do
+    flag_name=${spec%%:*}
+    flag_value=${spec#*:}
+    if [ "$flag_value" != "" ]; then
+        CLI_PARAMS="$CLI_PARAMS $flag_name $flag_value"
+    fi
+done
 
 if [ "$RESOURCE_PREFIX" != "" ]; then
     CLI_PARAMS="$CLI_PARAMS --resource-prefix $RESOURCE_PREFIX"

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Intel Corp. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"golang.org/x/sys/unix"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	allowedLogBase    = "/var/log"
+	defaultLogDir     = "/var/log/sriovdp"
+	defaultMaxSizeMB  = 100
+	defaultMaxFiles   = 5
+	defaultMaxAge     = 30
+	logFileName       = "sriovdp.log"
+	logDirPerms       = 0750
+	maxAllowedSizeMB  = 1024 // 1GB
+	maxAllowedFiles   = 100
+	maxAllowedAgeDays = 365
+)
+
+type Config struct {
+	LogDir     string
+	MaxSizeMB  int
+	MaxFiles   int
+	MaxAgeDays int
+	Compress   bool
+}
+
+type StartupInfo struct {
+	ConfigFile      string
+	ResourcePrefix  string
+	UseCdi          bool
+}
+
+func LogStartupHeader(info StartupInfo) {
+	separator := strings.Repeat("=", 80)
+
+	podName := os.Getenv("POD_NAME")
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	if podName == "" {
+		podName = hostname
+	}
+
+	glog.Infof("%s", separator)
+	glog.Infof("SR-IOV Network Device Plugin starting")
+	glog.Infof("Pod: %s | Start time: %s",
+		podName, time.Now().Format(time.RFC3339))
+	glog.Infof("Config file: %s | Resource prefix: %s | CDI: %v",
+		info.ConfigFile, info.ResourcePrefix, info.UseCdi)
+	glog.Infof("%s", separator)
+}
+
+// SetupLogRotation enables rotating file logs via stderr capture.
+// Prefer glog --log_dir when set. Returns cleanup to defer, or nil on failure.
+func SetupLogRotation(cfg Config) func() {
+	if f := flag.Lookup("log_dir"); f != nil {
+		if v := f.Value.String(); v != "" {
+			cfg.LogDir = v
+		}
+	}
+
+	logDir := cfg.LogDir
+	if logDir == "" {
+		logDir = DefaultConfig().LogDir
+	}
+	cleanDir, err := ValidateLogDir(logDir)
+	if err != nil {
+		glog.Errorf("rejected log directory: %v — continuing without rotation", err)
+		return nil
+	}
+	cfg.LogDir = cleanDir
+
+	resolved, warnings, err := ResolveConfig(cfg)
+	for _, w := range warnings {
+		glog.Warning(w)
+	}
+	if err != nil {
+		glog.Errorf("failed to resolve log rotation config: %v — continuing without rotation", err)
+		return nil
+	}
+
+	rotWriter, _, err := NewRotatingWriter(resolved)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sriovdp: log rotation disabled; cannot use log directory %q: %v\n", resolved.LogDir, err) //nolint:errcheck
+		glog.Errorf("failed to create log rotation writer: %v — continuing without rotation", err)
+		return nil
+	}
+
+	cleanup, err := CaptureStderr(rotWriter)
+	if err != nil {
+		glog.Errorf("failed to capture stderr for log rotation: %v — continuing without rotation", err)
+		if closeErr := rotWriter.Close(); closeErr != nil {
+			glog.Warningf("failed to close rotation writer after capture failure: %v", closeErr)
+		}
+		return nil
+	}
+
+	glog.Infof("Log rotation enabled: dir=%s maxSize=%dMB maxFiles=%d maxAge=%d compress=%v",
+		resolved.LogDir, resolved.MaxSizeMB, resolved.MaxFiles, resolved.MaxAgeDays, resolved.Compress)
+
+	return func() {
+		cleanup()
+		if err := rotWriter.Close(); err != nil {
+			glog.Warningf("failed to close rotation writer: %v", err)
+		}
+	}
+}
+
+// ValidateLogDir ensures dir is under /var/log, creates it, resolves symlinks,
+// and returns the real path.
+func ValidateLogDir(dir string) (string, error) {
+	if dir == "" {
+		return "", fmt.Errorf("log directory must not be empty")
+	}
+	if strings.Contains(dir, "~") {
+		return "", fmt.Errorf("log directory %q must not contain '~'", dir)
+	}
+	for _, part := range strings.Split(filepath.ToSlash(dir), "/") {
+		if part == ".." {
+			return "", fmt.Errorf("log directory %q must not contain '..'", dir)
+		}
+	}
+
+	clean := filepath.Clean(dir)
+	if !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("log directory %q must be an absolute path", dir)
+	}
+	if err := checkAllowedLogBase(clean); err != nil {
+		return "", fmt.Errorf("log directory %q is outside the allowed base %q", dir, allowedLogBase)
+	}
+
+	if err := os.MkdirAll(clean, logDirPerms); err != nil {
+		return "", fmt.Errorf("cannot create log directory %q: %w", clean, err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(clean)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve log directory %q: %w", clean, err)
+	}
+	resolved = filepath.Clean(resolved)
+	if err := checkAllowedLogBase(resolved); err != nil {
+		return "", fmt.Errorf("log directory %q resolves to %q which is outside the allowed base %q", dir, resolved, allowedLogBase)
+	}
+	return resolved, nil
+}
+
+func checkAllowedLogBase(path string) error {
+	if path != allowedLogBase && !strings.HasPrefix(path, allowedLogBase+"/") {
+		return fmt.Errorf("outside allowed base")
+	}
+	return nil
+}
+
+func ResolveConfig(cfg Config) (Config, []string, error) {
+	def := DefaultConfig()
+	normalized := cfg
+	warnings := []string{}
+
+	if normalized.LogDir == "" {
+		normalized.LogDir = def.LogDir
+	}
+	if normalized.MaxSizeMB <= 0 || normalized.MaxSizeMB > maxAllowedSizeMB {
+		warnings = append(warnings,
+			fmt.Sprintf("invalid --log-max-size=%d; using default %d", normalized.MaxSizeMB, def.MaxSizeMB))
+		normalized.MaxSizeMB = def.MaxSizeMB
+	}
+	if normalized.MaxFiles < 0 || normalized.MaxFiles > maxAllowedFiles {
+		warnings = append(warnings,
+			fmt.Sprintf("invalid --log-max-files=%d; using default %d", normalized.MaxFiles, def.MaxFiles))
+		normalized.MaxFiles = def.MaxFiles
+	}
+	if normalized.MaxAgeDays < 0 || normalized.MaxAgeDays > maxAllowedAgeDays {
+		warnings = append(warnings,
+			fmt.Sprintf("invalid --log-max-age=%d; using default %d", normalized.MaxAgeDays, def.MaxAgeDays))
+		normalized.MaxAgeDays = def.MaxAgeDays
+	}
+
+	normalized.Compress = true
+
+	return normalized, warnings, nil
+}
+
+// DefaultConfig returns production defaults.
+func DefaultConfig() Config {
+	return Config{
+		LogDir:     defaultLogDir,
+		MaxSizeMB:  defaultMaxSizeMB,
+		MaxFiles:   defaultMaxFiles,
+		MaxAgeDays: defaultMaxAge,
+		Compress:   true,
+	}
+}
+
+// NewRotatingWriter returns a lumberjack writer and any config warnings.
+// Caller must Close the writer.
+func NewRotatingWriter(cfg Config) (io.WriteCloser, []string, error) {
+	resolvedCfg, warnings, err := ResolveConfig(cfg)
+	if err != nil {
+		return nil, warnings, fmt.Errorf("invalid logging config: %w", err)
+	}
+
+	if err := os.MkdirAll(resolvedCfg.LogDir, logDirPerms); err != nil {
+		return nil, warnings, fmt.Errorf("cannot create log directory %q: %w", resolvedCfg.LogDir, err)
+	}
+
+	probe, err := os.CreateTemp(resolvedCfg.LogDir, ".probe-*")
+	if err != nil {
+		return nil, warnings, fmt.Errorf("log directory %q is not writable: %w", resolvedCfg.LogDir, err)
+	}
+	if err := probe.Close(); err != nil {
+		warnings = append(warnings, fmt.Sprintf("failed to close probe file: %v", err))
+	}
+	if err := os.Remove(probe.Name()); err != nil {
+		warnings = append(warnings, fmt.Sprintf("failed to remove probe file %q: %v", probe.Name(), err))
+	}
+
+	return &lumberjack.Logger{
+		Filename:   filepath.Join(resolvedCfg.LogDir, logFileName),
+		MaxSize:    resolvedCfg.MaxSizeMB,
+		MaxBackups: resolvedCfg.MaxFiles,
+		MaxAge:     resolvedCfg.MaxAgeDays,
+		Compress:   resolvedCfg.Compress,
+	}, warnings, nil
+}
+
+// resilientTeeWriter writes to primary + secondary; never fails the drain.
+type resilientTeeWriter struct {
+	primary   io.Writer // original stderr (or Discard after failure)
+	secondary io.Writer // rotating log (best-effort)
+}
+
+func (t *resilientTeeWriter) Write(p []byte) (int, error) {
+	if _, err := t.primary.Write(p); err != nil {
+		t.primary = io.Discard
+	}
+	_, _ = t.secondary.Write(p)
+	return len(p), nil // keep pipe drain alive
+}
+
+// CaptureStderr tees fd 2 to original stderr and w. Defer cleanup to restore fd 2.
+func CaptureStderr(w io.Writer) (cleanup func(), err error) {
+	if w == nil {
+		return nil, fmt.Errorf("writer must not be nil")
+	}
+
+	origFd, err := unix.Dup(int(os.Stderr.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("dup stderr: %w", err)
+	}
+
+	r, pw, err := os.Pipe()
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("create pipe: %w", err),
+			unix.Close(origFd),
+		)
+	}
+
+	if err := unix.Dup2(int(pw.Fd()), int(os.Stderr.Fd())); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("dup2 pipe to stderr: %w", err),
+			r.Close(),
+			pw.Close(),
+			unix.Close(origFd),
+		)
+	}
+
+	if err := pw.Close(); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("close pipe writer: %w", err),
+			unix.Dup2(origFd, int(os.Stderr.Fd())),
+			r.Close(),
+			unix.Close(origFd),
+		)
+	}
+
+	origFile := os.NewFile(uintptr(origFd), "original-stderr")
+	tee := &resilientTeeWriter{primary: origFile, secondary: w}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				_, _ = tee.Write(buf[:n])
+			}
+			if readErr != nil {
+				if readErr != io.EOF {
+					_, _ = fmt.Fprintf(origFile, "sriovdp: stderr tee read error: %v\n", readErr)
+				}
+				return
+			}
+		}
+	}()
+
+	return func() {
+		// Restore fd 2; closes pipe write end → drain gets EOF.
+		if err := unix.Dup2(origFd, int(os.Stderr.Fd())); err != nil {
+			_, _ = fmt.Fprintf(origFile, "sriovdp: failed to restore stderr: %v\n", err)
+		}
+		<-done // wait for drain before closing reader
+		if err := r.Close(); err != nil {
+			_, _ = fmt.Fprintf(origFile, "sriovdp: failed to close pipe reader: %v\n", err)
+		}
+		if err := origFile.Close(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "sriovdp: failed to close original stderr fd: %v\n", err)
+		}
+	}, nil
+}

--- a/pkg/logging/logging_setup_test.go
+++ b/pkg/logging/logging_setup_test.go
@@ -1,0 +1,188 @@
+// Copyright 2024 Intel Corp. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func saveAndRestoreLogDir() {
+	origVal := flag.Lookup("log_dir").Value.String()
+	DeferCleanup(func() {
+		_ = flag.Set("log_dir", origVal)
+	})
+}
+
+// varLogTempDir creates a temp dir under /var/log; skips if not writable.
+func varLogTempDir() string {
+	dir, err := os.MkdirTemp("/var/log", "sriovdp-test-*")
+	if err != nil {
+		Skip(fmt.Sprintf("cannot create test directory under /var/log: %v", err))
+	}
+	DeferCleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	return dir
+}
+
+var _ = Describe("ValidateLogDir", func() {
+	DescribeTable("rejects unsafe paths",
+		func(dir string) {
+			got, err := ValidateLogDir(dir)
+			Expect(err).To(HaveOccurred())
+			Expect(got).To(BeEmpty())
+		},
+		Entry("root", "/"),
+		Entry("tmp", "/tmp/logs"),
+		Entry("etc", "/etc/sriovdp"),
+		Entry("home", "/home/user/logs"),
+		Entry("traversal out of var/log", "/var/log/../etc"),
+		Entry("traversal to blabla", "/var/log/../blabla"),
+		Entry("root traversal to var/log", "/../var/log"),
+		Entry("relative traversal", "../var/log"),
+		Entry("tilde under var/log", "/var/log/~/blabla"),
+		Entry("relative path", "sriovdp"),
+		Entry("relative var/log", "var/log/sriovdp"),
+		Entry("var without log", "/var/sriovdp"),
+		Entry("var/log prefix trick", "/var/logextra"),
+		Entry("empty", ""),
+	)
+
+	It("accepts exact /var/log", func() {
+		got, err := ValidateLogDir("/var/log")
+		if err != nil {
+			Skip(fmt.Sprintf("cannot validate /var/log: %v", err))
+		}
+		Expect(got).To(Equal("/var/log"))
+	})
+
+	It("resolves a subdirectory under /var/log", func() {
+		dir := varLogTempDir()
+		got, err := ValidateLogDir(dir)
+		Expect(err).NotTo(HaveOccurred())
+		resolved, err := filepath.EvalSymlinks(dir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(filepath.Clean(resolved)))
+	})
+
+	It("cleans dot segments", func() {
+		dir := varLogTempDir()
+		got, err := ValidateLogDir(dir + "/.")
+		Expect(err).NotTo(HaveOccurred())
+		resolved, err := filepath.EvalSymlinks(dir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(filepath.Clean(resolved)))
+	})
+
+	It("rejects a symlink that escapes /var/log", func() {
+		dir := varLogTempDir()
+		link := filepath.Join(dir, "escape")
+		Expect(os.Symlink("/etc", link)).To(Succeed())
+		got, err := ValidateLogDir(link)
+		Expect(err).To(HaveOccurred())
+		Expect(got).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("outside the allowed base"))
+	})
+})
+
+var _ = Describe("SetupLogRotation", func() {
+	BeforeEach(func() {
+		saveAndRestoreLogDir()
+	})
+
+	It("falls back to the default log dir when unset", func() {
+		Expect(flag.Set("log_dir", "")).To(Succeed())
+
+		cfg := Config{MaxSizeMB: 100, MaxFiles: 5, MaxAgeDays: 30, Compress: true}
+		cleanup := SetupLogRotation(cfg)
+		if cleanup != nil {
+			cleanup()
+		}
+	})
+
+	It("enables rotation for a writable /var/log path", func() {
+		dir := varLogTempDir()
+		Expect(flag.Set("log_dir", dir)).To(Succeed())
+
+		cfg := Config{LogDir: dir, MaxSizeMB: 10, MaxFiles: 3, MaxAgeDays: 7, Compress: true}
+		cleanup := SetupLogRotation(cfg)
+		Expect(cleanup).NotTo(BeNil())
+
+		_, err := os.Stderr.WriteString("setup-test: logged line\n")
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup()
+
+		data, err := os.ReadFile(filepath.Join(dir, "sriovdp.log"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("setup-test: logged line"))
+	})
+
+	It("rejects a path outside /var/log", func() {
+		dir := GinkgoT().TempDir()
+		Expect(flag.Set("log_dir", dir)).To(Succeed())
+
+		cfg := Config{LogDir: dir, MaxSizeMB: 10, MaxFiles: 3, MaxAgeDays: 7, Compress: true}
+		cleanup := SetupLogRotation(cfg)
+		Expect(cleanup).To(BeNil())
+	})
+
+	It("falls back invalid limits to defaults without disabling rotation", func() {
+		dir := varLogTempDir()
+		Expect(flag.Set("log_dir", dir)).To(Succeed())
+
+		cfg := Config{LogDir: dir, MaxSizeMB: 0, MaxFiles: 5, MaxAgeDays: 30, Compress: true}
+		cleanup := SetupLogRotation(cfg)
+		Expect(cleanup).NotTo(BeNil())
+		cleanup()
+	})
+
+	It("restores stderr after cleanup", func() {
+		dir := varLogTempDir()
+		Expect(flag.Set("log_dir", dir)).To(Succeed())
+
+		cfg := Config{LogDir: dir, MaxSizeMB: 10, MaxFiles: 3, MaxAgeDays: 7, Compress: true}
+		cleanup := SetupLogRotation(cfg)
+		Expect(cleanup).NotTo(BeNil())
+
+		cleanup()
+
+		_, err := os.Stderr.WriteString("post-cleanup write OK\n")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("writes the log file at the configured directory", func() {
+		dir := varLogTempDir()
+		Expect(flag.Set("log_dir", dir)).To(Succeed())
+
+		cfg := Config{LogDir: dir, MaxSizeMB: 1, MaxFiles: 2, MaxAgeDays: 3, Compress: true}
+		cleanup := SetupLogRotation(cfg)
+		Expect(cleanup).NotTo(BeNil())
+
+		_, err := os.Stderr.WriteString("config passthrough test\n")
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup()
+
+		_, statErr := os.Stat(filepath.Join(dir, "sriovdp.log"))
+		Expect(statErr).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/logging/logging_suite_test.go
+++ b/pkg/logging/logging_suite_test.go
@@ -1,0 +1,13 @@
+package logging
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging Suite")
+}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,363 @@
+// Copyright 2024 Intel Corp. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+type failWriter struct {
+	failAfter int
+	writes    int
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes > w.failAfter {
+		return 0, errors.New("primary stderr broken")
+	}
+	return len(p), nil
+}
+
+var _ = Describe("DefaultConfig", func() {
+	It("returns production defaults", func() {
+		cfg := DefaultConfig()
+
+		Expect(cfg.LogDir).To(Equal("/var/log/sriovdp"))
+		Expect(cfg.MaxSizeMB).To(Equal(100))
+		Expect(cfg.MaxFiles).To(Equal(5))
+		Expect(cfg.MaxAgeDays).To(Equal(30))
+		Expect(cfg.Compress).To(BeTrue())
+		_, _, err := ResolveConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("ResolveConfig", func() {
+	DescribeTable("normalizes invalid values",
+		func(cfg Config, wantWarns int, expectSame bool) {
+			got, warnings, err := ResolveConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(HaveLen(wantWarns))
+			if expectSame {
+				Expect(got).To(Equal(cfg))
+			}
+		},
+		Entry("empty LogDir falls back to default",
+			Config{LogDir: "", MaxSizeMB: 100, MaxFiles: 5}, 0, false),
+		Entry("zero MaxSizeMB falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: 0, MaxFiles: 5}, 1, false),
+		Entry("negative MaxSizeMB falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: -1, MaxFiles: 5}, 1, false),
+		Entry("MaxSizeMB exceeds limit falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: 2000, MaxFiles: 5}, 1, false),
+		Entry("negative MaxFiles falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: 100, MaxFiles: -1}, 1, false),
+		Entry("MaxFiles exceeds limit falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: 100, MaxFiles: 200}, 1, false),
+		Entry("negative MaxAgeDays falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: 100, MaxFiles: 5, MaxAgeDays: -1}, 1, false),
+		Entry("MaxAgeDays exceeds limit falls back to default",
+			Config{LogDir: "/tmp", MaxSizeMB: 100, MaxFiles: 5, MaxAgeDays: 500}, 1, false),
+		Entry("valid values remain unchanged",
+			Config{LogDir: "/tmp", MaxSizeMB: 50, MaxFiles: 0, MaxAgeDays: 0, Compress: true}, 0, true),
+		Entry("valid production config",
+			Config{LogDir: "/var/log/sriovdp", MaxSizeMB: 100, MaxFiles: 5, MaxAgeDays: 30, Compress: true}, 0, true),
+	)
+
+	It("applies all fallbacks together", func() {
+		cfg := Config{
+			LogDir:     "",
+			MaxSizeMB:  0,
+			MaxFiles:   -1,
+			MaxAgeDays: 999,
+			Compress:   false,
+		}
+
+		normalized, warnings, err := ResolveConfig(cfg)
+		def := DefaultConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(normalized.LogDir).To(Equal(def.LogDir))
+		Expect(normalized.MaxSizeMB).To(Equal(def.MaxSizeMB))
+		Expect(normalized.MaxFiles).To(Equal(def.MaxFiles))
+		Expect(normalized.MaxAgeDays).To(Equal(def.MaxAgeDays))
+		Expect(normalized.Compress).To(BeTrue())
+		Expect(warnings).To(HaveLen(3))
+	})
+
+	It("leaves valid values unchanged", func() {
+		cfg := Config{
+			LogDir:     "/tmp/sriovdp-test",
+			MaxSizeMB:  12,
+			MaxFiles:   4,
+			MaxAgeDays: 7,
+			Compress:   true,
+		}
+
+		normalized, warnings, err := ResolveConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(normalized).To(Equal(cfg))
+		Expect(warnings).To(BeEmpty())
+	})
+})
+
+var _ = Describe("NewRotatingWriter", func() {
+	It("configures lumberjack with the resolved values", func() {
+		dir := GinkgoT().TempDir()
+		cfg := Config{
+			LogDir:     dir,
+			MaxSizeMB:  42,
+			MaxFiles:   7,
+			MaxAgeDays: 14,
+			Compress:   true,
+		}
+
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(w).NotTo(BeNil())
+
+		lj, ok := w.(*lumberjack.Logger)
+		Expect(ok).To(BeTrue())
+		Expect(lj.Filename).To(Equal(filepath.Join(dir, logFileName)))
+		Expect(lj.MaxSize).To(Equal(42))
+		Expect(lj.MaxBackups).To(Equal(7))
+		Expect(lj.MaxAge).To(Equal(14))
+		Expect(lj.Compress).To(BeTrue())
+	})
+
+	It("creates the log file on write", func() {
+		dir := GinkgoT().TempDir()
+		cfg := Config{LogDir: dir, MaxSizeMB: 10, MaxFiles: 3, MaxAgeDays: 7}
+
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, writeErr := w.Write([]byte("hello from rotating writer\n"))
+		Expect(writeErr).NotTo(HaveOccurred())
+		Expect(w.Close()).To(Succeed())
+
+		data, err := os.ReadFile(filepath.Join(dir, logFileName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("hello from rotating writer"))
+	})
+
+	It("fails for an invalid/unwritable directory", func() {
+		cfg := Config{LogDir: "/proc/1/fdinfo", MaxSizeMB: 10, MaxFiles: 3, MaxAgeDays: 7}
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).To(HaveOccurred())
+		Expect(w).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("log directory"))
+	})
+})
+
+var _ = Describe("resilientTeeWriter", func() {
+	It("keeps draining after primary write failure", func() {
+		primary := &failWriter{failAfter: 1}
+		var secondary bytes.Buffer
+		tee := &resilientTeeWriter{primary: primary, secondary: &secondary}
+
+		n, err := tee.Write([]byte("first\n"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(6))
+
+		n, err = tee.Write([]byte("second\n"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(7))
+
+		n, err = tee.Write([]byte("third\n"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(6))
+
+		Expect(tee.primary).To(Equal(io.Discard))
+		Expect(secondary.String()).To(Equal("first\nsecond\nthird\n"))
+		Expect(primary.writes).To(Equal(2))
+	})
+})
+
+var _ = Describe("CaptureStderr", func() {
+	It("rejects a nil writer", func() {
+		cleanup, err := CaptureStderr(nil)
+		Expect(err).To(HaveOccurred())
+		Expect(cleanup).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("writer must not be nil"))
+	})
+
+	It("tees stderr to the secondary writer", func() {
+		var buf bytes.Buffer
+		cleanup, err := CaptureStderr(&buf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cleanup).NotTo(BeNil())
+
+		_, writeErr := os.Stderr.WriteString("tee-test: this should appear in both destinations\n")
+		Expect(writeErr).NotTo(HaveOccurred())
+
+		cleanup()
+		Expect(buf.String()).To(ContainSubstring("tee-test: this should appear in both destinations"))
+	})
+
+	It("restores stderr after cleanup", func() {
+		var buf bytes.Buffer
+		cleanup, err := CaptureStderr(&buf)
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup()
+
+		_, writeErr := os.Stderr.WriteString("post-restore write\n")
+		Expect(writeErr).NotTo(HaveOccurred())
+	})
+
+	It("drains buffered data before cleanup returns", func() {
+		var buf bytes.Buffer
+		cleanup, err := CaptureStderr(&buf)
+		Expect(err).NotTo(HaveOccurred())
+
+		payload := strings.Repeat("X", 64*1024) + "\n"
+		_, writeErr := os.Stderr.WriteString(payload)
+		Expect(writeErr).NotTo(HaveOccurred())
+
+		cleanup()
+		Expect(buf.Len()).To(BeNumerically(">=", 64*1024))
+	})
+
+	It("supports multiple capture cycles", func() {
+		for i := 0; i < 3; i++ {
+			var buf bytes.Buffer
+			cleanup, err := CaptureStderr(&buf)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, writeErr := os.Stderr.WriteString("cycle message\n")
+			Expect(writeErr).NotTo(HaveOccurred())
+
+			cleanup()
+			Expect(buf.String()).To(ContainSubstring("cycle message"))
+		}
+
+		_, writeErr := os.Stderr.WriteString("after all cycles\n")
+		Expect(writeErr).NotTo(HaveOccurred())
+	})
+
+	It("integrates with a rotating writer", func() {
+		dir := GinkgoT().TempDir()
+		cfg := Config{LogDir: dir, MaxSizeMB: 1, MaxFiles: 2, MaxAgeDays: 1, Compress: false}
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup, err := CaptureStderr(w)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, writeErr := os.Stderr.WriteString("integration test: log line via stderr capture\n")
+		Expect(writeErr).NotTo(HaveOccurred())
+
+		cleanup()
+		Expect(w.Close()).To(Succeed())
+
+		data, err := os.ReadFile(filepath.Join(dir, logFileName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("integration test: log line via stderr capture"))
+	})
+})
+
+var _ = Describe("Rotation", func() {
+	It("retains at most MaxFiles backups plus the active file", func() {
+		dir := GinkgoT().TempDir()
+		cfg := Config{LogDir: dir, MaxSizeMB: 1, MaxFiles: 2, Compress: false}
+
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		chunk := strings.Repeat("B", 1024) + "\n"
+		for i := 0; i < 4096; i++ {
+			_, writeErr := w.Write([]byte(chunk))
+			Expect(writeErr).NotTo(HaveOccurred())
+		}
+		Expect(w.Close()).To(Succeed())
+
+		var fileCount int
+		Eventually(func() int {
+			entries, err := os.ReadDir(dir)
+			Expect(err).NotTo(HaveOccurred())
+			fileCount = 0
+			for _, e := range entries {
+				if !e.IsDir() {
+					fileCount++
+				}
+			}
+			return fileCount
+		}, time.Second, 50*time.Millisecond).Should(BeNumerically("<=", 3))
+
+		Expect(fileCount).To(BeNumerically(">=", 2))
+	})
+
+	It("compresses rotated backups when enabled", func() {
+		dir := GinkgoT().TempDir()
+		cfg := Config{LogDir: dir, MaxSizeMB: 1, MaxFiles: 3, Compress: true}
+
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		chunk := strings.Repeat("C", 1024) + "\n"
+		for i := 0; i < 2048; i++ {
+			_, writeErr := w.Write([]byte(chunk))
+			Expect(writeErr).NotTo(HaveOccurred())
+		}
+		Expect(w.Close()).To(Succeed())
+
+		Eventually(func() bool {
+			entries, err := os.ReadDir(dir)
+			Expect(err).NotTo(HaveOccurred())
+			for _, e := range entries {
+				if strings.HasSuffix(e.Name(), ".gz") {
+					return true
+				}
+			}
+			return false
+		}, 2*time.Second, 100*time.Millisecond).Should(BeTrue())
+	})
+})
+
+var _ = Describe("GracefulShutdown", func() {
+	It("preserves logs written before cleanup", func() {
+		dir := GinkgoT().TempDir()
+		cfg := Config{LogDir: dir, MaxSizeMB: 10, MaxFiles: 3, Compress: false}
+
+		w, _, err := NewRotatingWriter(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup, err := CaptureStderr(w)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = fmt.Fprintln(os.Stderr, "pre-shutdown: server stopping")
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup()
+		Expect(w.Close()).To(Succeed())
+
+		data, err := os.ReadFile(filepath.Join(dir, logFileName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("pre-shutdown: server stopping"))
+	})
+})


### PR DESCRIPTION
based [CNF-24291](https://redhat.atlassian.net/browse/CNF-24291)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable stderr log rotation with limits for size, file count, and retention age.
  * Added compressed log backups and startup configuration logging.
  * Added validation to ensure log directories remain within `/var/log`.
  * Updated deployment configurations to use `/var/log/sriovdp` for logs.
* **Bug Fixes**
  * Improved handling of invalid logging settings by applying safe defaults and warnings.
  * Preserved console logging while writing logs to rotating files.
* **Tests**
  * Added coverage for log rotation, directory validation, stderr capture, cleanup, compression, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->