### PR TITLE
Apply least-privilege best practices to DaemonSet

### DIFF
--- a/deployments/cdi/sriovdp-daemonset.yaml
+++ b/deployments/cdi/sriovdp-daemonset.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       hostNetwork: true
       serviceAccountName: sriov-device-plugin
+      automountServiceAccountToken: false
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
@@ -58,18 +59,14 @@ spec:
           privileged: false
           capabilities:
             add:
-              - BPF
-              - IPC_LOCK
               - NET_ADMIN
-              - NET_RAW
-              - SYS_ADMIN
-              - SYS_PTRACE
-              - SYS_RAWIO
             drop:
               - ALL
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             cpu: "250m"
@@ -85,13 +82,16 @@ spec:
         - name: plugins-registry
           mountPath: /var/lib/kubelet/plugins_registry
         - name: log
-          mountPath: /var/log
+          mountPath: /var/log/sriovdp
         - name: config-volume
           mountPath: /etc/pcidp
         - name: device-info
           mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
         - name: dynamic-cdi
           mountPath: /var/run/cdi
+        - name: sys
+          mountPath: /sys
+          readOnly: true
       volumes:
       - name: tmp
         emptyDir:
@@ -104,7 +104,8 @@ spec:
           path: /var/lib/kubelet/plugins_registry
       - name: log
         hostPath:
-          path: /var/log
+          path: /var/log/sriovdp
+          type: DirectoryOrCreate
       - name: device-info
         hostPath:
           path: /var/run/k8s.cni.cncf.io/devinfo/dp
@@ -119,3 +120,7 @@ spec:
         hostPath:
           path: /var/run/cdi
           type: DirectoryOrCreate
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory

--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -28,6 +28,7 @@ spec:
       hostNetwork: true
       hostUsers: true
       serviceAccountName: sriov-device-plugin
+      automountServiceAccountToken: false
       containers:
       - name: kube-sriovdp
         image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
@@ -39,18 +40,14 @@ spec:
           privileged: false
           capabilities:
             add:
-              - BPF
-              - IPC_LOCK
               - NET_ADMIN
-              - NET_RAW
-              - SYS_ADMIN
-              - SYS_PTRACE
-              - SYS_RAWIO
             drop:
               - ALL
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             cpu: "250m"
@@ -68,11 +65,14 @@ spec:
           mountPath: /var/lib/kubelet/plugins_registry
           readOnly: false
         - name: log
-          mountPath: /var/log
+          mountPath: /var/log/sriovdp
         - name: config-volume
           mountPath: /etc/pcidp
         - name: device-info
           mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+        - name: sys
+          mountPath: /sys
+          readOnly: true
       volumes:
         - name: tmp
           emptyDir:
@@ -85,7 +85,8 @@ spec:
             path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
-            path: /var/log
+            path: /var/log/sriovdp
+            type: DirectoryOrCreate
         - name: device-info
           hostPath:
             path: /var/run/k8s.cni.cncf.io/devinfo/dp
@@ -96,3 +97,7 @@ spec:
             items:
             - key: config.json
               path: config.json
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory


### PR DESCRIPTION
Use explicit capabilities instead of privileged mode, add a seccomp profile, and scope volume mounts to only the paths the plugin actually needs. Disable service account token automount since the plugin does not interact with the Kubernetes API.

Both the standard and CDI DaemonSet variants are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened security settings for the related DaemonSet pods.
  * Disabled automatic ServiceAccount token mounting, reduced container privileges, and applied a default seccomp profile.
  * Restricted Linux capabilities to network administration.
  * Updated storage mounts so logs are written to a dedicated path and the host `/sys` directory is mounted read-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->