### PR TITLE
Add Slingshot CXI Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ This plugin creates device plugin endpoints based on the configurations given in
             }]
         },
         {
+            "resourceName": "cxi",
+            "resourcePrefix": "hpe.com",
+            "selectors": [{
+                "vendors": ["1590"],
+                "devices": ["0372"],
+                "isCxi": true
+            }]
+        },
+        {
             "resourceName": "ct6dx_vdpa_vhost",
             "selectors": [{
                 "vendors": ["15b3"],
@@ -339,6 +348,7 @@ These selectors are applicable when "deviceType" is "netDevice" (note: this is d
 | "ddpProfiles"  | N        | A map of device selectors                                                | `string` list Default: `null`                       | "ddpProfiles": ["GTPv1-C/U IPv4/IPv6 payload"]                                                   |
 | "pKeys"        | N        | Infiniband Partition Keys. Will match only to the devices' default (index0) PKeys. Compatible only with linkTypes = infiniband | `string` list Default: `null`                       | "pKeys": ["0x1", "0xABCD", "0x50"]         |
 | "isRdma"       | N        | Mount RDMA resources. Incompatible with vdpaType                         | `bool` values `true` or `false` Default: `false`    | "isRdma": `true`                                                                                 |
+| "isCxi"        | N        | Mount the Cassini (CXI) `/dev/cxiN` char device associated with the VF   | `bool` values `true` or `false` Default: `false`    | "isCxi": `true`                                                                                  |
 | "needVhostNet" | N        | Share /dev/vhost-net and /dev/net/tun                                    | `bool` values `true` or `false` Default: `false`    | "needVhostNet": `true`                                                                           |
 | "vdpaType"     | N        | The type of vDPA device (virtio, vhost). Incompatible with isRdma = true | `string` values `vhost` or `virtio` Default: `null` | "vdpaType": "vhost"                                                                              |
 

--- a/deployments/configMap.yaml
+++ b/deployments/configMap.yaml
@@ -39,6 +39,15 @@ data:
                     "devices": ["1750"],
                     "drivers": ["bnxt_en"]
                 }
+            },
+            {
+                "resourceName": "cxi",
+                "resourcePrefix": "hpe.com",
+                "selectors": {
+                    "vendors": ["1590"],
+                    "devices": ["0372"],
+                    "isCxi": true
+                }
             }
         ]
     }

--- a/pkg/infoprovider/cxiInfoProvider.go
+++ b/pkg/infoprovider/cxiInfoProvider.go
@@ -62,8 +62,13 @@ func (ip *cxiInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 
 	// Confirm the corresponding /dev char device actually exists before mounting it.
 	devPath := filepath.Join(CxiDevDir, filepath.Base(cxiDev))
-	if _, err := os.Stat(devPath); err != nil {
+	info, err := os.Stat(devPath)
+	if err != nil {
 		glog.Errorf("GetDeviceSpecs(): cxi device file %s does not exist for device: %s, %s", devPath, ip.pciAddr, err.Error())
+		return devSpecs
+	}
+	if info.Mode()&os.ModeCharDevice == 0 {
+		glog.Errorf("GetDeviceSpecs(): cxi device file %s for device %s is not a character device", devPath, ip.pciAddr)
 		return devSpecs
 	}
 

--- a/pkg/infoprovider/cxiInfoProvider.go
+++ b/pkg/infoprovider/cxiInfoProvider.go
@@ -15,12 +15,19 @@
 package infoprovider
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/golang/glog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 )
+
+// CxiDevDir is the base directory for CXI char devices.
+// It is a variable to allow overriding the path in unit tests.
+var CxiDevDir = "/dev"
 
 /*
 cxiInfoProvider provides the Cassini (CXI) char device information.
@@ -50,6 +57,13 @@ func (ip *cxiInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	cxiDev, err := utils.GetCxiDeviceFile(ip.pciAddr)
 	if err != nil {
 		glog.Errorf("GetDeviceSpecs(): error getting cxi device file for device: %s, %s", ip.pciAddr, err.Error())
+		return devSpecs
+	}
+
+	// Confirm the corresponding /dev char device actually exists before mounting it.
+	devPath := filepath.Join(CxiDevDir, filepath.Base(cxiDev))
+	if _, err := os.Stat(devPath); err != nil {
+		glog.Errorf("GetDeviceSpecs(): cxi device file %s does not exist for device: %s, %s", devPath, ip.pciAddr, err.Error())
 		return devSpecs
 	}
 

--- a/pkg/infoprovider/cxiInfoProvider.go
+++ b/pkg/infoprovider/cxiInfoProvider.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Intel Corp. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infoprovider
+
+import (
+	"github.com/golang/glog"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
+)
+
+/*
+cxiInfoProvider provides the Cassini (CXI) char device information.
+It mounts the /dev/cxiN char device associated with a CXI VF into the container.
+*/
+type cxiInfoProvider struct {
+	pciAddr string
+}
+
+// NewCxiInfoProvider returns a new CXI Information Provider
+func NewCxiInfoProvider(pciAddr string) types.DeviceInfoProvider {
+	return &cxiInfoProvider{
+		pciAddr: pciAddr,
+	}
+}
+
+// *****************************************************************
+/* DeviceInfoProvider Interface */
+
+func (ip *cxiInfoProvider) GetName() string {
+	return "cxi"
+}
+
+func (ip *cxiInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
+	devSpecs := make([]*pluginapi.DeviceSpec, 0)
+
+	cxiDev, err := utils.GetCxiDeviceFile(ip.pciAddr)
+	if err != nil {
+		glog.Errorf("GetDeviceSpecs(): error getting cxi device file for device: %s, %s", ip.pciAddr, err.Error())
+		return devSpecs
+	}
+
+	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
+		HostPath:      cxiDev,
+		ContainerPath: cxiDev,
+		Permissions:   "rw",
+	})
+
+	return devSpecs
+}
+
+func (ip *cxiInfoProvider) GetEnvVal() types.AdditionalInfo {
+	envs := make(map[string]string, 0)
+
+	cxiDev, err := utils.GetCxiDeviceFile(ip.pciAddr)
+	if err != nil {
+		glog.Errorf("GetEnvVal(): error getting cxi device file for device: %s, %s", ip.pciAddr, err.Error())
+	} else {
+		envs["dev-mount"] = cxiDev
+	}
+
+	return envs
+}
+
+func (ip *cxiInfoProvider) GetMounts() []*pluginapi.Mount {
+	return nil
+}
+
+// *****************************************************************

--- a/pkg/infoprovider/cxiInfoProvider.go
+++ b/pkg/infoprovider/cxiInfoProvider.go
@@ -15,19 +15,12 @@
 package infoprovider
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/golang/glog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
 )
-
-// CxiDevDir is the base directory for CXI char devices.
-// It is a variable to allow overriding the path in unit tests.
-var CxiDevDir = "/dev"
 
 /*
 cxiInfoProvider provides the Cassini (CXI) char device information.
@@ -60,17 +53,9 @@ func (ip *cxiInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 		return devSpecs
 	}
 
-	// Confirm the corresponding /dev char device actually exists before mounting it.
-	devPath := filepath.Join(CxiDevDir, filepath.Base(cxiDev))
-	info, err := os.Stat(devPath)
-	if err != nil {
-		glog.Errorf("GetDeviceSpecs(): cxi device file %s does not exist for device: %s, %s", devPath, ip.pciAddr, err.Error())
-		return devSpecs
-	}
-	if info.Mode()&os.ModeCharDevice == 0 {
-		glog.Errorf("GetDeviceSpecs(): cxi device file %s for device %s is not a character device", devPath, ip.pciAddr)
-		return devSpecs
-	}
+	// Note: the existence of the /dev char device is intentionally not verified here.
+	// HostPath is resolved by kubelet on the host, whereas this code runs inside the
+	// device-plugin container which does not mount the host's /dev.
 
 	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 		HostPath:      cxiDev,

--- a/pkg/infoprovider/cxiInfoProvider_test.go
+++ b/pkg/infoprovider/cxiInfoProvider_test.go
@@ -51,8 +51,8 @@ var _ = Describe("cxiInfoProvider", func() {
 		),
 		Entry("cxi device present returns its char device mount",
 			&utils.FakeFilesystem{
-				Dirs:  []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
-				Files: map[string][]byte{"dev/cxi4": nil},
+				Dirs:     []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4", "dev"},
+				Symlinks: map[string]string{"dev/cxi4": "/dev/null"},
 			},
 			"0000:21:00.1",
 			[]*pluginapi.DeviceSpec{
@@ -62,6 +62,21 @@ var _ = Describe("cxiInfoProvider", func() {
 		Entry("cxi directory present but char device missing returns empty specs",
 			&utils.FakeFilesystem{
 				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
+			},
+			"0000:21:00.1",
+			[]*pluginapi.DeviceSpec{},
+		),
+		Entry("cxi path is a regular file returns empty specs",
+			&utils.FakeFilesystem{
+				Dirs:  []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4", "dev"},
+				Files: map[string][]byte{"dev/cxi4": nil},
+			},
+			"0000:21:00.1",
+			[]*pluginapi.DeviceSpec{},
+		),
+		Entry("cxi path is a directory returns empty specs",
+			&utils.FakeFilesystem{
+				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4", "dev/cxi4"},
 			},
 			"0000:21:00.1",
 			[]*pluginapi.DeviceSpec{},

--- a/pkg/infoprovider/cxiInfoProvider_test.go
+++ b/pkg/infoprovider/cxiInfoProvider_test.go
@@ -15,8 +15,6 @@
 package infoprovider_test
 
 import (
-	"path/filepath"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -36,7 +34,6 @@ var _ = Describe("cxiInfoProvider", func() {
 	DescribeTable("GetDeviceSpecs",
 		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
 			defer fs.Use()()
-			infoprovider.CxiDevDir = filepath.Join(fs.RootDir, "dev")
 
 			dip := infoprovider.NewCxiInfoProvider(pciAddr)
 			specs := dip.GetDeviceSpecs()
@@ -51,35 +48,12 @@ var _ = Describe("cxiInfoProvider", func() {
 		),
 		Entry("cxi device present returns its char device mount",
 			&utils.FakeFilesystem{
-				Dirs:     []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4", "dev"},
-				Symlinks: map[string]string{"dev/cxi4": "/dev/null"},
+				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
 			},
 			"0000:21:00.1",
 			[]*pluginapi.DeviceSpec{
 				{HostPath: "/dev/cxi4", ContainerPath: "/dev/cxi4", Permissions: "rw"},
 			},
-		),
-		Entry("cxi directory present but char device missing returns empty specs",
-			&utils.FakeFilesystem{
-				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
-			},
-			"0000:21:00.1",
-			[]*pluginapi.DeviceSpec{},
-		),
-		Entry("cxi path is a regular file returns empty specs",
-			&utils.FakeFilesystem{
-				Dirs:  []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4", "dev"},
-				Files: map[string][]byte{"dev/cxi4": nil},
-			},
-			"0000:21:00.1",
-			[]*pluginapi.DeviceSpec{},
-		),
-		Entry("cxi path is a directory returns empty specs",
-			&utils.FakeFilesystem{
-				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4", "dev/cxi4"},
-			},
-			"0000:21:00.1",
-			[]*pluginapi.DeviceSpec{},
 		),
 	)
 	Describe("getting mounts", func() {

--- a/pkg/infoprovider/cxiInfoProvider_test.go
+++ b/pkg/infoprovider/cxiInfoProvider_test.go
@@ -15,6 +15,8 @@
 package infoprovider_test
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -34,6 +36,7 @@ var _ = Describe("cxiInfoProvider", func() {
 	DescribeTable("GetDeviceSpecs",
 		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
 			defer fs.Use()()
+			infoprovider.CxiDevDir = filepath.Join(fs.RootDir, "dev")
 
 			dip := infoprovider.NewCxiInfoProvider(pciAddr)
 			specs := dip.GetDeviceSpecs()
@@ -48,12 +51,20 @@ var _ = Describe("cxiInfoProvider", func() {
 		),
 		Entry("cxi device present returns its char device mount",
 			&utils.FakeFilesystem{
-				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
+				Dirs:  []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
+				Files: map[string][]byte{"dev/cxi4": nil},
 			},
 			"0000:21:00.1",
 			[]*pluginapi.DeviceSpec{
 				{HostPath: "/dev/cxi4", ContainerPath: "/dev/cxi4", Permissions: "rw"},
 			},
+		),
+		Entry("cxi directory present but char device missing returns empty specs",
+			&utils.FakeFilesystem{
+				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
+			},
+			"0000:21:00.1",
+			[]*pluginapi.DeviceSpec{},
 		),
 	)
 	Describe("getting mounts", func() {

--- a/pkg/infoprovider/cxiInfoProvider_test.go
+++ b/pkg/infoprovider/cxiInfoProvider_test.go
@@ -1,0 +1,78 @@
+// Copyright 2018 Intel Corp. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infoprovider_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/infoprovider"
+	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
+)
+
+var _ = Describe("cxiInfoProvider", func() {
+	Describe("creating new cxiInfoProvider", func() {
+		It("should return valid cxiInfoProvider object", func() {
+			dip := infoprovider.NewCxiInfoProvider("fakePCIAddr")
+			Expect(dip).NotTo(BeNil())
+			Expect(dip.GetName()).To(Equal("cxi"))
+		})
+	})
+	DescribeTable("GetDeviceSpecs",
+		func(fs *utils.FakeFilesystem, pciAddr string, expected []*pluginapi.DeviceSpec) {
+			defer fs.Use()()
+
+			dip := infoprovider.NewCxiInfoProvider(pciAddr)
+			specs := dip.GetDeviceSpecs()
+			Expect(specs).To(ConsistOf(expected))
+		},
+		Entry("no cxi directory returns empty specs",
+			&utils.FakeFilesystem{
+				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1"},
+			},
+			"0000:21:00.1",
+			[]*pluginapi.DeviceSpec{},
+		),
+		Entry("cxi device present returns its char device mount",
+			&utils.FakeFilesystem{
+				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
+			},
+			"0000:21:00.1",
+			[]*pluginapi.DeviceSpec{
+				{HostPath: "/dev/cxi4", ContainerPath: "/dev/cxi4", Permissions: "rw"},
+			},
+		),
+	)
+	Describe("getting mounts", func() {
+		It("should always return empty array of mounts", func() {
+			dip := infoprovider.NewCxiInfoProvider("fakeAddr")
+			Expect(dip.GetMounts()).To(BeEmpty())
+		})
+	})
+	Describe("getting env val", func() {
+		It("should return the cxi device mount", func() {
+			pciAddr := "0000:21:00.1"
+			fs := &utils.FakeFilesystem{
+				Dirs: []string{"sys/bus/pci/devices/0000:21:00.1/cxi/cxi4"},
+			}
+			defer fs.Use()()
+
+			dip := infoprovider.NewCxiInfoProvider(pciAddr)
+			envs := dip.GetEnvVal()
+			Expect(envs).To(HaveKeyWithValue("dev-mount", "/dev/cxi4"))
+		})
+	})
+})

--- a/pkg/netdevice/netDeviceProvider.go
+++ b/pkg/netdevice/netDeviceProvider.go
@@ -143,7 +143,7 @@ func (np *netDeviceProvider) GetFilteredDevices(devices []types.HostDevice,
 	if nf.IsCxi {
 		cxiDevices := make([]types.HostDevice, 0)
 		for _, dev := range filteredDevice {
-			if utils.HasCxiDevice(dev.(types.PciNetDevice).GetPciAddr()) {
+			if utils.HasCxiDevice(dev.GetDeviceID()) {
 				cxiDevices = append(cxiDevices, dev)
 			}
 		}

--- a/pkg/netdevice/netDeviceProvider.go
+++ b/pkg/netdevice/netDeviceProvider.go
@@ -143,7 +143,7 @@ func (np *netDeviceProvider) GetFilteredDevices(devices []types.HostDevice,
 	if nf.IsCxi {
 		cxiDevices := make([]types.HostDevice, 0)
 		for _, dev := range filteredDevice {
-			if utils.HasCxiDevice(dev.GetDeviceID()) {
+			if utils.HasCxiDevice(dev.(types.PciNetDevice).GetPciAddr()) {
 				cxiDevices = append(cxiDevices, dev)
 			}
 		}

--- a/pkg/netdevice/netDeviceProvider.go
+++ b/pkg/netdevice/netDeviceProvider.go
@@ -139,6 +139,17 @@ func (np *netDeviceProvider) GetFilteredDevices(devices []types.HostDevice,
 		filteredDevice = rdmaDevices
 	}
 
+	// filter for cxi (Cassini) devices
+	if nf.IsCxi {
+		cxiDevices := make([]types.HostDevice, 0)
+		for _, dev := range filteredDevice {
+			if utils.HasCxiDevice(dev.(types.PciNetDevice).GetPciAddr()) {
+				cxiDevices = append(cxiDevices, dev)
+			}
+		}
+		filteredDevice = cxiDevices
+	}
+
 	// filter for vDPA-capable devices
 	if nf.VdpaType != "" {
 		vdpaDevices := make([]types.HostDevice, 0)

--- a/pkg/netdevice/pciNetDevice.go
+++ b/pkg/netdevice/pciNetDevice.go
@@ -74,6 +74,13 @@ func NewPciNetDevice(dev *ghw.PCIDevice,
 				glog.Warningf("RDMA resources for %s not found. Are RDMA modules loaded?", dev.Address)
 			}
 		}
+		if nf.IsCxi {
+			if utils.HasCxiDevice(dev.Address) {
+				infoProviders = append(infoProviders, infoprovider.NewCxiInfoProvider(dev.Address))
+			} else {
+				glog.Warningf("CXI device for %s not found. Is the cxi driver loaded?", dev.Address)
+			}
+		}
 		if nf.NeedVhostNet {
 			if infoprovider.VhostNetDeviceExist() {
 				infoProviders = append(infoProviders, infoprovider.NewVhostNetInfoProvider())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -126,6 +126,7 @@ type GenericNetDeviceSelectors struct {
 	RootDevices  []string `json:"rootDevices,omitempty"`
 	LinkTypes    []string `json:"linkTypes,omitempty"`
 	IsRdma       bool     // the resource support rdma
+	IsCxi        bool     // the resource is a Cassini (CXI) device with a /dev/cxiN char device
 	AcpiIndexes  []string `json:"acpiIndexes,omitempty"`
 	NeedVhostNet bool     `json:"needVhostNet,omitempty"` // share vhost-net along the selected resource
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -395,12 +395,12 @@ func GetCxiDeviceFile(dev string) (devFile string, err error) {
 
 	_, err = os.Lstat(cxiDir)
 	if err != nil {
-		return "", fmt.Errorf("GetCxiDeviceFile(): could not get directory information for device: %s Err: %v", cxiDir, err)
+		return "", fmt.Errorf("GetCxiDeviceFile(): could not get directory information for device: %s Err: %w", cxiDir, err)
 	}
 
 	files, err := os.ReadDir(cxiDir)
 	if err != nil {
-		return "", fmt.Errorf("GetCxiDeviceFile(): failed to read cxi directory %s: %v", cxiDir, err)
+		return "", fmt.Errorf("GetCxiDeviceFile(): failed to read cxi directory %s: %w", cxiDir, err)
 	}
 
 	if len(files) == 0 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -378,6 +378,42 @@ func GetUIODeviceFile(dev string) (devFile string, err error) {
 	return
 }
 
+// HasCxiDevice returns true if the PCI device has an associated Cassini (CXI) char device
+func HasCxiDevice(pciAddr string) bool {
+	cxiDir := filepath.Join(sysBusPci, pciAddr, "cxi")
+	files, err := os.ReadDir(cxiDir)
+	if err != nil {
+		return false
+	}
+	return len(files) > 0
+}
+
+// GetCxiDeviceFile returns the Cassini (CXI) char device file (e.g. /dev/cxi4)
+// for a CXI PCI device given its PCI address
+func GetCxiDeviceFile(dev string) (devFile string, err error) {
+	cxiDir := filepath.Join(sysBusPci, dev, "cxi")
+
+	_, err = os.Lstat(cxiDir)
+	if err != nil {
+		return "", fmt.Errorf("GetCxiDeviceFile(): could not get directory information for device: %s Err: %v", cxiDir, err)
+	}
+
+	files, err := os.ReadDir(cxiDir)
+	if err != nil {
+		return "", fmt.Errorf("GetCxiDeviceFile(): failed to read cxi directory %s: %v", cxiDir, err)
+	}
+
+	if len(files) == 0 {
+		return "", fmt.Errorf("GetCxiDeviceFile(): no cxi device found under %s", cxiDir)
+	}
+
+	// cxi directory should contain a single entry e.g. cxi4
+	// with a corresponding device file in /dev e.g. /dev/cxi4
+	devFile = filepath.Join(devDir, files[0].Name())
+
+	return devFile, nil
+}
+
 // GetNetNames returns host net interface names as string for a PCI device from its pci address
 func GetNetNames(pciAddr string) ([]string, error) {
 	netDir := filepath.Join(sysBusPci, pciAddr, "net")


### PR DESCRIPTION
## Description
Similar to RDMA devices, Slingshot CXI NIC devices need to be mounted in the pods.
However, the `isRdma` flag only looks in /dev/infiniband. To avoid confusion between devices, decided to add a separate `isCxi` config flag. If true, the CXI device associated with the VF net interface will be mounted.

Also added example to usage docs.

Fixes #734 

## Testing
Modified the sample test yaml:
```
cn-0007:~ # cat pod-tc1.yaml
apiVersion: v1
kind: Pod
metadata:
  name: testpod1
  annotations:
    k8s.v1.cni.cncf.io/networks: cxi-net
spec:
  containers:
  - name: appcntr1
    image: docker.io/flannel/flannel:v0.25.2
    imagePullPolicy: IfNotPresent
    command: [ "/bin/bash", "-c", "--" ]
    args: [ "while true; do sleep 300000; done;" ]
    resources:
      requests:
        hpe.com/cxi: '1'
      limits:
        hpe.com/cxi: '1'
```

And verified both the ethernet interface and CXI device is configured in the pod:
```
cn-0007:~ # kubectl exec testpod1 -- sh -c 'ls /dev/cxi* 2>/dev/null; echo "PCIDEVICE_HPE_COM_CXI=$PCIDEVICE_HPE_COM_CXI"; ip addr show net1'
/dev/cxi37
PCIDEVICE_HPE_COM_CXI=0000:5a:00.1
109: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
    link/ether 02:00:01:00:08:1b brd ff:ff:ff:ff:ff:ff
    altname enp90s0f1
    inet 10.150.200.30/16 brd 10.150.255.255 scope global net1
       valid_lft forever preferred_lft forever
    inet6 fe80::1ff:fe00:81b/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
cn-0007:~ #
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for Cassini (CXI) devices.
- CXI devices can be selected using the `isCxi` configuration field.
- Detected CXI character devices are exposed to workloads at `/dev/cxiN`.
- Added a sample `cxi` resource configuration, including the deployment ConfigMap.

## Documentation
- Documented the `isCxi` selector and its device-mounting behavior.

## Tests
- Added coverage for CXI device discovery, selection, and missing-device scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->