### PR TITLE
Validate resourcePrefix to prevent path traversal

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/jaypipes/ghw"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	cdiPkg "github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/cdi"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/factory"
@@ -209,6 +210,10 @@ func (rm *resourceManager) validConfigs() bool {
 		// resourcePrefix might be overridden for a given resource pool
 		resourcePrefix := rm.cliParams.resourcePrefix
 		if conf.ResourcePrefix != "" {
+			if errs := validation.IsDNS1123Subdomain(conf.ResourcePrefix); len(errs) > 0 {
+				glog.Errorf("invalid resource prefix %q: %v", conf.ResourcePrefix, errs)
+				return false
+			}
 			resourcePrefix = conf.ResourcePrefix
 		}
 

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/accelerator"
 	"github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/auxnetdevice"
@@ -56,6 +57,9 @@ func (rf *resourceFactory) GetResourceServer(rp types.ResourcePool) (types.Resou
 	if rp != nil {
 		prefix := rf.endPointPrefix
 		if prefixOverride := rp.GetResourcePrefix(); prefixOverride != "" {
+			if errs := validation.IsDNS1123Subdomain(prefixOverride); len(errs) > 0 {
+				return nil, fmt.Errorf("factory: invalid resource prefix %q: %v", prefixOverride, errs)
+			}
 			prefix = prefixOverride
 		}
 		return resources.NewResourceServer(prefix, rf.endPointSuffix, rf.pluginWatch, rf.useCdi, rp), nil

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -639,6 +639,16 @@ var _ = Describe("Factory", func() {
 				Expect(rs).To(BeNil())
 			})
 		})
+		Context("when resource pool uses invalid prefix", func() {
+			f := factory.NewResourceFactory("fake", "fake", true, false)
+			rp := mocks.ResourcePool{}
+			rp.On("GetResourcePrefix").Return("/invalid")
+			rs, e := f.GetResourceServer(&rp)
+			It("should fail", func() {
+				Expect(e).To(HaveOccurred())
+				Expect(rs).To(BeNil())
+			})
+		})
 		Context("when resource pool uses overridden prefix", func() {
 			f := factory.NewResourceFactory("fake", "fake", true, false)
 			rp := mocks.ResourcePool{}

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -58,9 +58,16 @@ const (
 // NewResourceServer returns an instance of ResourceServer
 func NewResourceServer(prefix, suffix string, pluginWatch, useCdi bool, rp types.ResourcePool) types.ResourceServer {
 	sockName := fmt.Sprintf("%s_%s.%s", prefix, rp.GetResourceName(), suffix)
-	sockPath := filepath.Join(types.SockDir, sockName)
+	baseDir := types.SockDir
 	if !pluginWatch {
-		sockPath = filepath.Join(types.DeprecatedSockDir, sockName)
+		baseDir = types.DeprecatedSockDir
+	}
+	sockPath := filepath.Join(baseDir, sockName)
+	if !strings.HasPrefix(filepath.Clean(sockPath), filepath.Clean(baseDir)+string(filepath.Separator)) {
+		glog.Errorf("computed socket path %q escapes base directory %q; using sanitized prefix", sockPath, baseDir)
+		prefix = "invalid-prefix"
+		sockName = fmt.Sprintf("invalid-prefix_%s.%s", rp.GetResourceName(), suffix)
+		sockPath = filepath.Join(baseDir, sockName)
 	}
 
 	//nolint:mnd


### PR DESCRIPTION
The resourcePrefix field from the device plugin ConfigMap was used unsanitized in socket path construction, CDI spec naming, and device info file paths. A malicious prefix containing path separators could escape the base directory via filepath.Join normalization.

Add ValidResourcePrefix regex validation in validConfigs() and defense-in-depth checks in GetResourceServer() and NewResourceServer().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configured resource prefixes are now validated, and invalid values are rejected before resource services are created.
  * Invalid socket paths that would escape the intended socket directory now return an error instead of creating a service with a modified path.
  * Valid custom prefixes and existing default behavior remain supported.

* **Tests**
  * Added coverage for invalid resource prefixes and socket paths, confirming that no resource service is created when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->