### PR TITLE
ci: restrict fork e2e runs and enable maintainer comment trigger

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -92,6 +92,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
       - name: lint test
@@ -105,6 +106,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        ref: ${{ inputs.ref || github.ref }}
         persist-credentials: false
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
@@ -117,6 +119,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        ref: ${{ inputs.ref || github.ref }}
         persist-credentials: false
     - uses: hadolint/hadolint-action@v3.3.0
       name: Run Hadolint
@@ -129,6 +132,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        ref: ${{ inputs.ref || github.ref }}
         persist-credentials: false
 
     - name: Set up Go

--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Build
         run: make build
@@ -44,6 +45,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Install hwdata
         run: sudo apt-get install hwdata -y
@@ -62,6 +64,9 @@ jobs:
           go-version: 1.25.x
 
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Install hwdata
         run: sudo apt-get install hwdata -y
@@ -86,6 +91,8 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: lint test
         run: make lint
@@ -97,6 +104,8 @@ jobs:
       SHELLCHECK_OPTS: -e SC3037 # disabled because of false issue in entrypoint.sh ln 14-21. Not using any complicated flags. Works with alpines almquist shell.
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       with:
@@ -107,6 +116,8 @@ jobs:
     name: Hadolint
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: hadolint/hadolint-action@v3.3.0
       name: Run Hadolint
       with:
@@ -117,6 +128,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -142,26 +155,29 @@ jobs:
     runs-on: [ sriov ]
     env:
       TEST_REPORT_PATH: k8s-artifacts
+      PR_NUM: ${{ inputs.pr_number || github.event.pull_request.number || github.run_id }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: build sriov-network-device-plugin image
-        run: podman build -f images/Dockerfile -t ghaction-sriov-network-device-plugin:pr-${{ inputs.pr_number || github.event.pull_request.number }} .
+        run: podman build -f images/Dockerfile -t "ghaction-sriov-network-device-plugin:pr-${PR_NUM}" .
 
       - name: Check out sriov operator's code
         uses: actions/checkout@v7
         with:
           repository: k8snetworkplumbingwg/sriov-network-operator
           path: sriov-network-operator-wc
+          persist-credentials: false
 
       - name: run test
         run: make test-e2e-conformance-virtual-k8s-cluster-ci
         working-directory: sriov-network-operator-wc
         env:
-          LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE: ghaction-sriov-network-device-plugin:pr-${{ inputs.pr_number || github.event.pull_request.number }}
+          LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE: ghaction-sriov-network-device-plugin:pr-${PR_NUM}
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -1,5 +1,17 @@
 name: build-test-lint
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number'
+        required: false
+        type: string
+      ref:
+        description: 'Git ref / commit SHA'
+        required: false
+        type: string
 jobs:
   build:
     name: build
@@ -12,6 +24,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Build
         run: make build
@@ -28,6 +42,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install hwdata
         run: sudo apt-get install hwdata -y
@@ -118,15 +134,22 @@ jobs:
   sriov-operator-e2e-test:
     name: SR-IOV operator e2e tests
     needs: [ build,test ]
+    # Prevent auto-executing on external fork PRs to protect private self-hosted runners
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [ sriov ]
     env:
       TEST_REPORT_PATH: k8s-artifacts
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: build sriov-network-device-plugin image
-        run: podman build -f images/Dockerfile -t ghaction-sriov-network-device-plugin:pr-${{github.event.pull_request.number}} .
+        run: podman build -f images/Dockerfile -t ghaction-sriov-network-device-plugin:pr-${{ inputs.pr_number || github.event.pull_request.number }} .
 
       - name: Check out sriov operator's code
         uses: actions/checkout@v7
@@ -138,7 +161,7 @@ jobs:
         run: make test-e2e-conformance-virtual-k8s-cluster-ci
         working-directory: sriov-network-operator-wc
         env:
-          LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE: ghaction-sriov-network-device-plugin:pr-${{github.event.pull_request.number}}
+          LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE: ghaction-sriov-network-device-plugin:pr-${{ inputs.pr_number || github.event.pull_request.number }}
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/e2e-comment-trigger.yml
+++ b/.github/workflows/e2e-comment-trigger.yml
@@ -1,0 +1,83 @@
+name: e2e-comment-trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+  issues: write
+
+jobs:
+  e2e-trigger:
+    name: Trigger E2E on Slash Command
+    if: |
+      github.event.issue.pull_request &&
+      (contains(github.event.comment.body, '/test-all') || contains(github.event.comment.body, '/test-sriov-operator-e2e-test'))
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check author permissions
+        id: check-perm
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const association = context.payload.comment.author_association;
+            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+
+            if (allowed.includes(association)) {
+              console.log(`User ${commenter} is authorized via association: ${association}`);
+              return;
+            }
+
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: commenter,
+            });
+
+            if (!['admin', 'write'].includes(perm.permission)) {
+              core.setFailed(`User ${commenter} does not have write access to trigger e2e tests.`);
+            }
+
+      - name: Add reaction and dispatch E2E workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            if (pr.state !== 'open') {
+              core.setFailed(`PR #${prNumber} is not open.`);
+              return;
+            }
+
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'rocket'
+              });
+            } catch (err) {
+              console.log('Failed to add reaction:', err);
+            }
+
+            console.log(`Dispatching build-test-lint.yml for PR #${prNumber} on ref ${pr.head.sha}`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-test-lint.yml',
+              ref: context.repo.default_branch,
+              inputs: {
+                pr_number: String(prNumber),
+                ref: pr.head.sha
+              }
+            });

--- a/.github/workflows/e2e-comment-trigger.yml
+++ b/.github/workflows/e2e-comment-trigger.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check author permissions
         id: check-perm
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const commenter = context.payload.comment.user.login;
@@ -43,7 +43,7 @@ jobs:
             }
 
       - name: Add reaction and dispatch E2E workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const prNumber = context.payload.issue.number;
@@ -69,13 +69,14 @@ jobs:
               console.log('Failed to add reaction:', err);
             }
 
-            console.log(`Dispatching build-test-lint.yml for PR #${prNumber} on ref ${pr.head.sha}`);
+            const defaultBranch = context.payload.repository.default_branch;
+            console.log(`Dispatching build-test-lint.yml for PR #${prNumber} on ref ${pr.head.sha} (workflow ref: ${defaultBranch})`);
 
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build-test-lint.yml',
-              ref: context.repo.default_branch,
+              ref: defaultBranch,
               inputs: {
                 pr_number: String(prNumber),
                 ref: pr.head.sha


### PR DESCRIPTION
## Summary
- **Restrict auto-execution on self-hosted runners**: Skips `sriov-operator-e2e-test` automatically when a PR originates from an external fork to protect self-hosted runner infrastructure.
- **Workflow Dispatch Support**: Adds `workflow_dispatch` trigger and `ref`/`pr_number` input variables to `.github/workflows/build-test-lint.yml`.
- **Maintainer Slash Command Trigger**: Adds `.github/workflows/e2e-comment-trigger.yml` listening for `/test-all` and `/test-sriov-operator-e2e-test` issue comments on PRs. Verifies maintainer permissions (`OWNER`, `MEMBER`, `COLLABORATOR`, or write permission) before dispatching the E2E workflow on the PR head commit.

## Test plan
1. Opened fork PRs will automatically skip `sriov-operator-e2e-test` on initial creation.
2. Maintainers commenting `/test-all` or `/test-sriov-operator-e2e-test` on the PR will trigger permission validation.
3. Once validated, the `e2e-comment-trigger` workflow reacts with `🚀` and dispatches `build-test-lint.yml` to run E2E tests against the PR code on the `[sriov]` runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added manual test runs with selectable pull requests and code revisions.
* Added comment commands to start comprehensive validation for open pull requests.
* Added access checks so only authorized contributors can initiate test runs.
* Added visual confirmation when a requested test run is accepted.
* Improved test execution flexibility across pull requests, revisions, and supported test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->