### PR TITLE
deployments: pin DaemonSet image references to release digest

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,22 @@ updates:
   commit-message:
     prefix: "chore:"
 
+- package-ecosystem: "docker"
+  directory: "/deployments"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  commit-message:
+    prefix: "chore:"
+
+- package-ecosystem: "docker"
+  directory: "/deployments/cdi"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  commit-message:
+    prefix: "chore:"
+
 # GitHub Actions
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/deployments/cdi/sriovdp-daemonset.yaml
+++ b/deployments/cdi/sriovdp-daemonset.yaml
@@ -48,7 +48,8 @@ spec:
                 - s390x
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
+        # Pin to immutable release digest (CWE-494)
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.11.0@sha256:7c5901727d4500f103f038c178b41dc6450afa6f324306c1973495c9a7c4f5a5
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/deployments/sriovdp-daemonset.yaml
+++ b/deployments/sriovdp-daemonset.yaml
@@ -29,7 +29,8 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
+        # Pin to immutable release digest (CWE-494)
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.11.0@sha256:7c5901727d4500f103f038c178b41dc6450afa6f324306c1973495c9a7c4f5a5
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/docs/config-file/README.md
+++ b/docs/config-file/README.md
@@ -54,7 +54,8 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest
+        # Pin to immutable release digest (CWE-494)
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.11.0@sha256:7c5901727d4500f103f038c178b41dc6450afa6f324306c1973495c9a7c4f5a5
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp

--- a/docs/config-file/README.md
+++ b/docs/config-file/README.md
@@ -54,8 +54,8 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        # Pin to immutable release digest (CWE-494)
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.11.0@sha256:7c5901727d4500f103f038c178b41dc6450afa6f324306c1973495c9a7c4f5a5
+        # Refer to deployments/sriovdp-daemonset.yaml for the pinned release image and digest
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:<release-tag>
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp


### PR DESCRIPTION
## Summary
- Pin container image references in DaemonSet deployment manifests and docs to immutable release digest `ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.11.0@sha256:7c5901727d4500f103f038c178b41dc6450afa6f324306c1973495c9a7c4f5a5` instead of `:latest` tag (Fixes #739, CWE-494).
- Add Dependabot configuration entries for `/deployments` and `/deployments/cdi` directories to automatically update Docker image digests in deployment manifests.

## Test plan
- Verify Dependabot YAML syntax is valid (`.github/dependabot.yaml`).
- Verify DaemonSet manifest syntax is valid (`deployments/sriovdp-daemonset.yaml` & `deployments/cdi/sriovdp-daemonset.yaml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added weekly automated updates for deployment container images.
  * Pinned SR-IOV device plugin deployments to version 3.11.0 with immutable image digests, replacing the floating `latest` tag.
  * Updated configuration documentation to use a release placeholder and direct users to the deployment manifest for the pinned image and digest.
  * Improved deployment consistency and reliability by ensuring released images remain unchanged after publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->